### PR TITLE
Feat: implement redirection via zero module

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,7 +15,8 @@ export default {
       siteUrl: 'https://fil.org'
     },
     redirects: [
-      { from: '/filplus', to: '/governance/#panel-3-title' }
+      { from: '/filplus', to: '/governance/#panel-3-title' },
+      { from: '/asd', to: '/governance' }
     ]
   },
   // --------------------------------------------------------- [Runtime] Private

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,7 +15,15 @@ export default {
       siteUrl: 'https://fil.org'
     },
     redirects: [
-      { from: '/filplus', to: '/governance/#panel-3-title' }
+      { from: '/blog', to: 'https://filecoinfoundation.medium.com/' },
+      { from: '/board', to: '/about/#panel_1' },
+      { from: '/careers', to: '/get-involved/#careers_intro' },
+      { from: '/community', to: '/about/#dive_deeper_intro' },
+      { from: '/contact', to: '/about/#site-footer' },
+      { from: '/filplus', to: '/governance/#panel-3-title' },
+      { from: '/fips', to: '/governance/#panel-1-title' },
+      { from: '/philosophy', to: '/about/#intro_1' },
+      { from: '/team', to: '/about/#panel_1' }
     ]
   },
   // --------------------------------------------------------- [Runtime] Private

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -81,7 +81,10 @@ export default {
       toaster: {
         display: 10,
         timeout: 5000
-      }
+      },
+      redirects: [
+        { from: '/filplus', to: '/governance/#panel-3-title' }
+      ]
     },
     filters: {
       include: false

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -13,7 +13,10 @@ export default {
     seo: {
       siteName: 'Filecoin Foundation',
       siteUrl: 'https://fil.org'
-    }
+    },
+    redirects: [
+      { from: '/filplus', to: '/governance/#panel-3-title' }
+    ]
   },
   // --------------------------------------------------------- [Runtime] Private
   privateRuntimeConfig: {},
@@ -81,10 +84,7 @@ export default {
       toaster: {
         display: 10,
         timeout: 5000
-      },
-      redirects: [
-        { from: '/filplus', to: '/governance/#panel-3-title' }
-      ]
+      }
     },
     filters: {
       include: false

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -15,8 +15,7 @@ export default {
       siteUrl: 'https://fil.org'
     },
     redirects: [
-      { from: '/filplus', to: '/governance/#panel-3-title' },
-      { from: '/asd', to: '/governance' }
+      { from: '/filplus', to: '/governance/#panel-3-title' }
     ]
   },
   // --------------------------------------------------------- [Runtime] Private

--- a/package-lock.json
+++ b/package-lock.json
@@ -4234,9 +4234,9 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "au-nuxt-module-zero": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.2.tgz",
-      "integrity": "sha512-gcTi4QCSeB9ldOCatd58W9I8OK52QI6d0goxuT5W0ifjYKhOZ+u9i4wk9380PypBm33eAduOXW5jeRjGdmTOvg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.5.tgz",
+      "integrity": "sha512-jMxQaxL+ea7moIsBH4cuunNhbh4cN5XWEt8QF6r1bMakWjRr3rwajkpmvcXmYuFTi4DJlnI+y/vIhtoqZPdnnA==",
       "requires": {
         "cookie": "^0.4.1",
         "lodash": "^4.17.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3196,6 +3196,47 @@
         "http-proxy-middleware": "^1.0.6"
       }
     },
+    "@nuxtjs/sitemap": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/sitemap/-/sitemap-2.4.0.tgz",
+      "integrity": "sha512-TVgIYOtPp7KAfaUo76WRpGbO20j4D/xi/A7shFIGjARHs+FvfAWXNCtBT87dTwe/RoYzAsEKtijFFUTaSu5bUA==",
+      "requires": {
+        "async-cache": "^1.1.0",
+        "consola": "^2.13.0",
+        "etag": "^1.8.1",
+        "fresh": "^0.5.2",
+        "fs-extra": "^8.1.0",
+        "is-https": "^2.0.2",
+        "lodash.unionby": "^4.8.0",
+        "minimatch": "^3.0.4",
+        "sitemap": "^4.1.1"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        }
+      }
+    },
     "@nuxtjs/style-resources": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@nuxtjs/style-resources/-/style-resources-1.2.1.tgz",
@@ -3299,6 +3340,14 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.4.tgz",
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
+    },
+    "@types/sax": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.3.tgz",
+      "integrity": "sha512-+QSw6Tqvs/KQpZX8DvIl3hZSjNFLW/OqE5nlyHXtTwODaJvioN2rOWpBNEWZp2HZUFhOh+VohmJku/WxEXU2XA==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/source-list-map": {
       "version": "0.1.2",
@@ -4207,6 +4256,30 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.1.tgz",
       "integrity": "sha512-XdD5lRO/87udXCMC9meWdYiR+Nq6ZjUfXidViUZGu2F1MO4T3XwZ1et0hb2++BgLfhyJwy44BGB/yx80ABx8hg=="
     },
+    "async-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/async-cache/-/async-cache-1.1.0.tgz",
+      "integrity": "sha1-SppaidBl7F2OUlS9nulrp2xTK1o=",
+      "requires": {
+        "lru-cache": "^4.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -4234,10 +4307,11 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "au-nuxt-module-zero": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.5.tgz",
-      "integrity": "sha512-jMxQaxL+ea7moIsBH4cuunNhbh4cN5XWEt8QF6r1bMakWjRr3rwajkpmvcXmYuFTi4DJlnI+y/vIhtoqZPdnnA==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/au-nuxt-module-zero/-/au-nuxt-module-zero-1.0.8.tgz",
+      "integrity": "sha512-eFHjctI6IH106kMuMioFBZRw2Q2fy9BV8+sVSlffWHSGG94HLqgQBngCLaivEq0nPYmp+O5fuHG3NVamxOhIzQ==",
       "requires": {
+        "@nuxtjs/sitemap": "^2.4.0",
         "cookie": "^0.4.1",
         "lodash": "^4.17.21",
         "nuxt-hammer": "^2.1.3",
@@ -8631,6 +8705,11 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-https": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-https/-/is-https-2.0.2.tgz",
+      "integrity": "sha512-UfUCKVQH/6PQRCh5Qk9vNu4feLZiFmV/gr8DjbtJD0IrCRIDTA6E+d/AVFGPulI5tqK5W45fYbn1Nir1O99rFw=="
+    },
     "is-negative-zero": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
@@ -9024,6 +9103,11 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM="
+    },
+    "lodash.unionby": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
+      "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -12592,6 +12676,30 @@
         "totalist": "^1.0.0"
       }
     },
+    "sitemap": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-4.1.1.tgz",
+      "integrity": "sha512-+8yd66IxyIFEMFkFpVoPuoPwBvdiL7Ap/HS5YD7igqO4phkyTPFIprCAE9NMHehAY5ZGN3MkAze4lDrOAX3sVQ==",
+      "requires": {
+        "@types/node": "^12.0.2",
+        "@types/sax": "^1.2.0",
+        "arg": "^4.1.1",
+        "sax": "^1.2.4",
+        "xmlbuilder": "^13.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.20.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.36.tgz",
+          "integrity": "sha512-+5haRZ9uzI7rYqzDznXgkuacqb6LJhAti8mzZKWxIXn/WEtvB+GHVJ7AuMwcN1HMvXOSJcrvA6PPoYHYOYYebA=="
+        },
+        "arg": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+          "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+        }
+      }
+    },
     "slice-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
@@ -14665,6 +14773,11 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz",
       "integrity": "sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw=="
+    },
+    "xmlbuilder": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-13.0.2.tgz",
+      "integrity": "sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@nuxtjs/eslint-module": "^3.0.2",
     "@nuxtjs/moment": "^1.6.1",
     "@nuxtjs/style-resources": "^1.2.1",
-    "au-nuxt-module-zero": "^1.0.2",
+    "au-nuxt-module-zero": "^1.0.5",
     "babel-eslint": "^10.0.1",
     "easing-utils": "0.0.7",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@nuxtjs/eslint-module": "^3.0.2",
     "@nuxtjs/moment": "^1.6.1",
     "@nuxtjs/style-resources": "^1.2.1",
-    "au-nuxt-module-zero": "^1.0.5",
+    "au-nuxt-module-zero": "^1.0.8",
     "babel-eslint": "^10.0.1",
     "easing-utils": "0.0.7",
     "eslint": "^7.32.0",

--- a/pages/filplus.vue
+++ b/pages/filplus.vue
@@ -1,7 +1,0 @@
-<script>
-export default {
-  asyncData ({ redirect }) {
-    return redirect('/governance/#panel-3-title')
-  }
-}
-</script>

--- a/pages/filplus.vue
+++ b/pages/filplus.vue
@@ -1,0 +1,7 @@
+<script>
+export default {
+  asyncData ({ redirect }) {
+    return redirect('/governance/#panel-3-title')
+  }
+}
+</script>


### PR DESCRIPTION
Redirects can now be added to the `publicRuntimeConfig` object in `nuxt.config.js` in the following format:

```js
redirects: [
  { from: '/path-a', to: 'path-b' }
]
```