### PR TITLE
Feat: zero floating wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,37 @@ Below is a list of icon values that can be passed into any `icon` property in th
 
 - `play`
 - `info`
+
+**FloatingMenu**
+
+Below is a list of icon values that can be passed into any `icon` property in the component objects:
+
+```js
+props: {
+  id: String, // id of the component instance (optional)
+  cutoff: String, // id of an element on the page which when reached will cancel the floating effect (required)
+  offsettop: Number, // how far the threshold to enable floating is placed in advance of the viewport top (in pixels) (optional)
+  offsetbottom: Number, // how far the threshold to disable floating is placed in advance of the viewport bottom (in pixels) (optional)
+  content: String, // inline html to be injected as floating content (optional)
+  entries: [ // an array of objects with menu items. The following is an example of the format:
+    {
+      "heading": "Heading 1",
+      "id": "heading-1-id",
+      "items": [ // an array of subheadings
+        {
+          "text": "Subheading 1",
+          "id": "subheading-1-id"
+        },
+        {
+          "text": "Subheading 2",
+          "id": "subheading-2-id"
+        },
+        {
+          "text": "Subheading 3",
+          "id": "subheading-3-id"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/components/FloatingMenu.vue
+++ b/components/FloatingMenu.vue
@@ -2,8 +2,9 @@
   <Zero_Core__FloatingWrapper
     :id="id"
     v-slot="scope"
-    :thresholdoffset="threshold"
-    :cutoffid="cutoff">
+    :thresholdoffset="offsettop"
+    :cutoffid="cutoff"
+    :bottomoffset="offsetbottom">
 
     <template v-if="entries.length">
       <div
@@ -25,9 +26,11 @@
       </div>
     </template>
 
-    <template v-if="block.type === 'image_block'">
-      <img :src="block.src" class="image" />
-    </template>
+    <div
+      v-if="content"
+      class="custom-content"
+      v-html="content">
+    </div>
 
   </Zero_Core__FloatingWrapper>
 </template>
@@ -43,24 +46,29 @@ export default {
       required: false,
       default: 'floating-menu'
     },
-    cutoff: {
-      type: String,
-      required: true
-    },
-    threshold: {
+    offsettop: {
       type: Number,
       required: false,
       default: 120
+    },
+    offsetbottom: {
+      type: Number,
+      required: false,
+      default: 120
+    },
+    cutoff: {
+      type: String,
+      required: true
     },
     entries: {
       type: Array,
       required: false,
       default: () => []
     },
-    block: {
-      type: Object,
+    content: {
+      type: String,
       required: false,
-      default: () => {}
+      default: ''
     }
   }
 }
@@ -68,8 +76,21 @@ export default {
 
 <style lang="scss" scoped>
 // ///////////////////////////////////////////////////////////////////// General
+.custom-content {
+  width: 100%;
+}
+
 .image {
   display: block;
   width: 100%;
 }
+
+.anchor-container,
+.floating-content,
+.image {
+  @include mini {
+    z-index: -1;
+  }
+}
+
 </style>

--- a/components/FloatingMenu.vue
+++ b/components/FloatingMenu.vue
@@ -1,111 +1,66 @@
 <template>
-  <div id="sticky-info" ref="parent">
-    <div
-      :class="['sticky-content', { 'info-fixed': sticky }]"
-      :style="`transform: ${transform}`">
+  <Zero_Core__FloatingWrapper
+    :id="id"
+    v-slot="scope"
+    :thresholdoffset="threshold"
+    :cutoffid="cutoff">
+
+    <template v-if="entries.length">
       <div
         v-for="(entry, entryIndex) in entries"
         :key="`entry-${entryIndex}`">
         <div
           class="heading"
-          @click="jumpToSection(entry.id)">
+          @click="scope.jump(entry.id)">
           {{ entry.heading }}
         </div>
         <ul>
           <li
             v-for="(item, itemIndex) in entry.items"
             :key="`entry-${itemIndex}`"
-            @click="jumpToSection(item.id)">
+            @click="scope.jump(item.id)">
             {{ item.text }}
           </li>
         </ul>
       </div>
-    </div>
-  </div>
+    </template>
+
+    <template v-if="block.type === 'image_block'">
+      <img :src="block.src" class="image" />
+    </template>
+
+  </Zero_Core__FloatingWrapper>
 </template>
 
 <script>
-// =================================================================== Functions
-const stickyElementInViewport = (instance, lowerBoundElementID) => {
-  const element = instance.$refs.parent
-  const coords = getElementDocumentCoords(element)
-  const elementTop = coords.top
-  const elementLeft = coords.left
-  const threshold = window.pageYOffset + 120
-
-  const section = document.getElementById(lowerBoundElementID)
-  const sectionTop = getElementDocumentCoords(section).top
-
-  if (elementTop < threshold && sectionTop > threshold) {
-    if (!instance.sticky) {
-      instance.sticky = true
-    }
-    instance.transform = `translate(${elementLeft}px, 0px)` // outside of if statement for resize
-  } else if (sectionTop < threshold) {
-    if (instance.sticky) {
-      instance.sticky = false
-      instance.transform = `translate(0px, ${sectionTop - elementTop}px)`
-    }
-  } else {
-    if (instance.sticky) {
-      instance.sticky = false
-      instance.transform = 'translate(0px, 0px)'
-    }
-  }
-}
-
-const getElementDocumentCoords = (elem) => {
-  const box = elem.getBoundingClientRect()
-
-  const body = document.body
-  const docEl = document.documentElement
-
-  const scrollTop = window.pageYOffset || docEl.scrollTop || body.scrollTop
-  const scrollLeft = window.pageXOffset || docEl.scrollLeft || body.scrollLeft
-
-  const clientTop = docEl.clientTop || body.clientTop || 0
-  const clientLeft = docEl.clientLeft || body.clientLeft || 0
-
-  const top = box.top + scrollTop - clientTop
-  const left = box.left + scrollLeft - clientLeft
-
-  return { top: Math.round(top), left: Math.round(left) }
-}
-
 // ====================================================================== Export
 export default {
   name: 'FloatingMenu',
 
   props: {
+    id: {
+      type: String,
+      required: false,
+      default: 'floating-menu'
+    },
+    cutoff: {
+      type: String,
+      required: true
+    },
+    threshold: {
+      type: Number,
+      required: false,
+      default: 120
+    },
     entries: {
       type: Array,
-      required: true
-    }
-  },
-
-  data () {
-    return {
-      sticky: false,
-      transform: 'translate(0px, 0px)'
-    }
-  },
-
-  mounted () {
-    this.scroll = () => { stickyElementInViewport(this, 'section-6') }
-    window.addEventListener('scroll', this.scroll)
-    this.resize = () => { stickyElementInViewport(this, 'section-6') }
-    window.addEventListener('resize', this.resize)
-  },
-
-  beforeDestroy () {
-    if (this.scroll) { window.removeEventListener('scroll', this.scroll) }
-    if (this.resize) { window.removeEventListener('resize', this.resize) }
-  },
-
-  methods: {
-    jumpToSection (section) {
-      const element = document.getElementById(section) || document.querySelector(`[data-id='${section}']`)
-      this.$scrollToElement(element, 0, -50)
+      required: false,
+      default: () => []
+    },
+    block: {
+      type: Object,
+      required: false,
+      default: () => {}
     }
   }
 }
@@ -113,9 +68,8 @@ export default {
 
 <style lang="scss" scoped>
 // ///////////////////////////////////////////////////////////////////// General
-.heading {
-  cursor: pointer;
-  z-index: 10000;
+.image {
+  display: block;
+  width: 100%;
 }
-
 </style>

--- a/content/pages/governance.json
+++ b/content/pages/governance.json
@@ -83,6 +83,8 @@
             {
               "name": "FloatingMenu",
               "props": {
+                "id": "governance-floating-menu",
+                "cutoff": "section-6",
                 "entries": [
                   {
                     "heading": "Improving Filecoin",

--- a/content/pages/governance.json
+++ b/content/pages/governance.json
@@ -85,6 +85,7 @@
               "props": {
                 "id": "governance-floating-menu",
                 "cutoff": "section-6",
+                "offsetbottom": 0,
                 "entries": [
                   {
                     "heading": "Improving Filecoin",

--- a/content/pages/grants.json
+++ b/content/pages/grants.json
@@ -70,7 +70,7 @@
       {
         "id": "gallery-1-cards",
         "left": {
-          "type": "text_block",
+          "type": "image_block",
           "cols": {
             "num": "col-4_mi-8",
             "push_left": "off-2_mi-2"

--- a/content/pages/grants.json
+++ b/content/pages/grants.json
@@ -72,8 +72,8 @@
         "left": {
           "type": "text_block",
           "cols": {
-            "num": "col-3_mi-6",
-            "push_left": "off-2_mi-3"
+            "num": "col-4_mi-8",
+            "push_left": "off-2_mi-2"
           },
           "customizations": [
             {
@@ -81,10 +81,9 @@
               "props": {
                 "id": "floating-hands",
                 "cutoff": "more-info",
-                "block": {
-                  "type": "image_block",
-                  "src": "/icons/hands-opening.png"
-                }
+                "offsettop": 200,
+                "offsetbottom": 100,
+                "content": "<img src='/icons/hands-opening.png' class='image'/>"
               }
             }
           ]
@@ -93,7 +92,7 @@
           "type": "slider_block",
           "cols": {
             "num": "col-4_mi-10",
-            "push_left": "off-3_sm-2_mi-1"
+            "push_left": "off-2_sm-2_mi-1"
           },
           "cards": [
             {

--- a/content/pages/grants.json
+++ b/content/pages/grants.json
@@ -70,12 +70,24 @@
       {
         "id": "gallery-1-cards",
         "left": {
-          "type": "image_block",
-          "src": "/icons/hands-opening.png",
+          "type": "text_block",
           "cols": {
             "num": "col-3_mi-6",
             "push_left": "off-2_mi-3"
-          }
+          },
+          "customizations": [
+            {
+              "name": "FloatingMenu",
+              "props": {
+                "id": "floating-hands",
+                "cutoff": "more-info",
+                "block": {
+                  "type": "image_block",
+                  "src": "/icons/hands-opening.png"
+                }
+              }
+            }
+          ]
         },
         "right": {
           "type": "slider_block",
@@ -107,7 +119,7 @@
             },
             {
               "type": "A",
-              "description": "<span class='more-info'>For more information on grants, <a href='mailto:devgrants@fil.org'>email us</a> or see our <a href='https://github.com/filecoin-project/devgrants' target='_blank' class='lighter'>Github repo</a> for a more in-depth introduction to the grants program.</span>"
+              "description": "<span id='more-info'>For more information on grants, <a href='mailto:devgrants@fil.org'>email us</a> or see our <a href='https://github.com/filecoin-project/devgrants' target='_blank' class='lighter'>Github repo</a> for a more in-depth introduction to the grants program.</span>"
             }
           ]
         }

--- a/pages/governance.vue
+++ b/pages/governance.vue
@@ -273,18 +273,9 @@ $indentedFill__Left: calc(50% - (#{$containerWidth} / 2) + (14 * 1.75rem));
 }
 // ----------------------------------------------------------------- [Section] 3
 
-::v-deep #sticky-info {
-  position: relative;
-  z-index: 10000;
-  .sticky-content {
-    position: absolute;
-    top: 0;
+::v-deep #governance-floating-menu {
+  .floating-content {
     left: -4rem;
-    z-index: 10000;
-    &.info-fixed {
-      position: fixed;
-      top: 120px;
-    }
     .heading {
       @include fontSize_ExtraLarge;
       @include fontWeight_Medium;

--- a/pages/grants.vue
+++ b/pages/grants.vue
@@ -200,13 +200,14 @@ export default {
   @include mini {
     padding: 3rem 0 0 0;
   }
-  .column-content {
+  .column-content,
+  .blocks {
     &.left {
+      width: 100%;
       .image {
-        transform: scale(1.4) translateY(25%);
-        @include small {
-          transform: scale(1.3) translateY(0);
-          margin-bottom: 6rem;
+        width: 100%;
+        @include mini {
+          opacity: 0.5;
         }
       }
     }

--- a/pages/grants.vue
+++ b/pages/grants.vue
@@ -234,9 +234,6 @@ export default {
       @include mini {
         margin-bottom: 2rem;
       }
-      .more-info {
-        @include fontSize_Large;
-      }
     }
   }
   a {
@@ -246,6 +243,10 @@ export default {
       color: $jordyBlue;
     }
   }
+}
+
+::v-deep #more-info {
+  @include fontSize_Large;
 }
 
 ::v-deep #banner-1 {


### PR DESCRIPTION
The floating menu component has been abstracted out into the zero module core. It is still inserted in the same way through the page json content but new props have been added:

- `offsetTop` (number in pixels)
- `offsetBottom` (number in pixels)
- `content` (optional html can be injected to replace the menu, for example an image)

See the updated README for more info