### PR TITLE
fix Concentric border radii

### DIFF
--- a/components/BackgroundLayers.vue
+++ b/components/BackgroundLayers.vue
@@ -5,7 +5,7 @@
       v-for="(layer, i) in layers"
       :key="layer.color"
       :class="[`layer shadow__${layer.index} shadow-strength-${shadowStrength} border-radius-direction-${borderRadiusDirection}`, { reverse }]"
-      :style="layerStyle(i + 1, i, layer.color)">
+      :style="layerStyle(i + 1, layer.color)">
     </div>
 
   </div>
@@ -17,16 +17,33 @@ import Throttle from 'lodash/throttle'
 
 // =================================================================== Functions
 const setBackgroundLayerWidth = (instance) => {
+  const map = new Map([
+    ['ultralarge', '140.625rem'],
+    ['xlarge', '90rem'],
+    ['large', '75rem'],
+    ['medium', '64rem'],
+    ['small', '53.125rem'],
+    ['mini', '40rem'],
+    ['tiny', '25.9375rem']
+  ])
+
   let reset = true
   for (const breakpoint in instance.breakpoints) {
-    if (window.matchMedia(`(max-width: ${breakpoint})`).matches) {
+    if (window.matchMedia(`(max-width: ${map.get(breakpoint)})`).matches) {
       if (reset) { reset = false }
-      if (instance.layerWidth !== instance.breakpoints[breakpoint]) {
-        instance.layerWidth = instance.breakpoints[breakpoint]
+      if (instance.layerWidth !== instance.breakpoints[breakpoint].stroke) {
+        instance.layerWidth = instance.breakpoints[breakpoint].stroke
+      }
+      if (instance.borderRadius !== instance.breakpoints[breakpoint].radius) {
+        instance.borderRadius = instance.breakpoints[breakpoint].radius
       }
     } else if (reset) {
-      if (instance.layerWidth !== 1.375) {
+      if (instance.breakpoints.default) {
+        instance.layerWidth = instance.breakpoints.default.stroke || 1.375
+        instance.borderRadius = instance.breakpoints.default.radius || 12.75
+      } else {
         instance.layerWidth = 1.375
+        instance.borderRadius = 12.75
       }
     }
   }
@@ -37,11 +54,6 @@ export default {
   name: 'BackgroundLayers',
 
   props: {
-    borderRadius: {
-      type: Number,
-      required: false,
-      default: 10
-    },
     layersArray: {
       type: String,
       required: false,
@@ -52,7 +64,12 @@ export default {
       required: false,
       default: false
     },
-    offset: {
+    print: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    breakpoints: {
       type: Object,
       required: false,
       default: () => {
@@ -75,6 +92,7 @@ export default {
     return {
       colors: ['#EFF6FC', '#D8EBFB', '#73B4ED', '#0090FF', '#154ED9', '#0621A4', '#06094E', '#08072E'],
       layerWidth: 1.375,
+      borderRadius: 12.75,
       resize: false
     }
   },
@@ -88,17 +106,6 @@ export default {
         arr.push({ index: ind, color: this.colors[ind - 1] })
       }
       return arr
-    },
-    breakpoints () {
-      const data = {}
-      if (this.offset.hasOwnProperty('ultralarge')) { data['140.625rem'] = this.offset.ultralarge }
-      if (this.offset.hasOwnProperty('xlarge')) { data['90rem'] = this.offset.xlarge }
-      if (this.offset.hasOwnProperty('large')) { data['75rem'] = this.offset.large }
-      if (this.offset.hasOwnProperty('medium')) { data['64rem'] = this.offset.medium }
-      if (this.offset.hasOwnProperty('small')) { data['53.125rem'] = this.offset.small }
-      if (this.offset.hasOwnProperty('mini')) { data['40rem'] = this.offset.mini }
-      if (this.offset.hasOwnProperty('tiny')) { data['25.9375rem'] = this.offset.tiny }
-      return data
     }
   },
 
@@ -113,14 +120,14 @@ export default {
   },
 
   methods: {
-    layerStyle (index, order, color) {
+    layerStyle (index, color) {
       const w = `width: calc(100% + ${2 * index * this.layerWidth}rem);`
       const h = `height: calc(100% + ${2 * index * this.layerWidth}rem);`
       const t = `top: ${-1 * index * this.layerWidth}rem;`
       const l = `left: ${-1 * index * this.layerWidth}rem;`
-      const z = `z-index: ${-1 * (order + 1)};`
+      const z = `z-index: ${-1 * index};`
       const c = `background-color: ${color};`
-      const b = `border-radius: ${this.borderRadius + (2 * this.layerWidth) + (1 * this.layerWidth * index)}rem;`
+      const b = `border-radius: ${this.borderRadius + (this.layerWidth * (index - 1))}rem;`
       return `${w} ${h} ${t} ${l} ${z} ${c} ${b}`
     }
   }

--- a/components/Navigation/NavMegaMenu.vue
+++ b/components/Navigation/NavMegaMenu.vue
@@ -184,7 +184,7 @@ export default {
     visibility 250ms linear, left 250ms ease-out, width 250ms, height 250ms, transform 250ms;
   background-color: $denim;
   border: 5px solid $azureRadiance;
-  border-radius: 0.875rem 0.875rem 5.25rem 5.25rem;
+  border-radius: 1.0625rem 1.0625rem 5.25rem 5.25rem;
   color: $white;
 
   &:before {
@@ -196,7 +196,7 @@ export default {
     height: calc(100% - 10px);
     background-color: $blackPearl;
     border: 5px solid $kleinBlue;
-    border-radius: 0.625rem 0.625rem 4.75rem 4.75rem;
+    border-radius: 0.4375rem 0.4375rem 4.75rem 4.75rem;
   }
 
   animation-duration: 250ms;

--- a/components/SiteNavigation.vue
+++ b/components/SiteNavigation.vue
@@ -5,7 +5,7 @@
         <div class="content">
           <component
             :is="navigationComponentType"
-            @panel-open="toggleScrollClass"/>
+            @panel-open="toggleScrollClass" />
         </div>
       </div>
     </div>

--- a/content/pages/about.json
+++ b/content/pages/about.json
@@ -43,9 +43,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4_3",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 10
+                  }
                 },
                 "reverse": true
               }
@@ -99,8 +109,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6",
-                "offset": {
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 12.75
+                  }
                 },
                 "reverse": true
               }
@@ -202,10 +223,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4",
-                "border-radius": 5,
-                "offset": {
-                  "small": 1,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "small": {
+                    "stroke": 1,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 5
+                  }
                 },
                 "reverse": true
               }

--- a/content/pages/basic-template-2.json
+++ b/content/pages/basic-template-2.json
@@ -37,9 +37,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4_3",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 10
+                  }
                 },
                 "reverse": true
               }
@@ -181,8 +191,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6",
-                "offset": {
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 12.75
+                  }
                 },
                 "reverse": true
               }

--- a/content/pages/ecosystem.json
+++ b/content/pages/ecosystem.json
@@ -38,9 +38,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4_3",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 10
+                  }
                 },
                 "reverse": true
               }
@@ -162,8 +172,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6",
-                "offset": {
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 12.75
+                  }
                 },
                 "reverse": true
               }

--- a/content/pages/filaustin.json
+++ b/content/pages/filaustin.json
@@ -220,9 +220,15 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "1_2_3_4_5_6",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 5
+                  }
                 },
                 "shadow-strength": "small",
                 "border-radius-direction": "reverse"

--- a/content/pages/get-involved.json
+++ b/content/pages/get-involved.json
@@ -140,8 +140,11 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6",
-                "offset": {
-                  "mini": 0.25
+                "breakpoints": {
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 5
+                  }
                 },
                 "reverse": true
               }

--- a/content/pages/governance.json
+++ b/content/pages/governance.json
@@ -248,10 +248,16 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "4_5_6",
-                "offset": {
-                  "mini": 0.25
-                },
-                "border-radius": 6.375
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 10.375
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 7.25
+                  }
+                }
               }
             }
           },

--- a/content/pages/grants.json
+++ b/content/pages/grants.json
@@ -32,8 +32,15 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "5_6",
-                "offset": {
-                  "mini": 0.75
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.75,
+                    "radius": 5
+                  }
                 }
               }
             }
@@ -128,8 +135,11 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6",
-                "offset": {
-                  "mini": 1.375
+                "breakpoints": {
+                  "mini": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  }
                 },
                 "reverse": true
               }
@@ -294,11 +304,13 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6",
-                "offset": {
-                  "mini": 1.375
+                "breakpoints": {
+                  "mini": {
+                    "stroke": 1.375,
+                    "radius": 5
+                  }
                 },
-                "reverse": true,
-                "border-radius": 5
+                "reverse": true
               }
             }
           },

--- a/content/pages/index.json
+++ b/content/pages/index.json
@@ -43,9 +43,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4_3_2",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 10
+                  }
                 },
                 "reverse": true
               }
@@ -102,9 +112,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4_3_2",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 10
+                  }
                 },
                 "reverse": true
               }
@@ -326,9 +346,19 @@
               "name": "BackgroundLayers",
               "props": {
                 "layers-array": "8_6_5_4",
-                "offset": {
-                  "medium": 0.75,
-                  "mini": 0.25
+                "breakpoints": {
+                  "default": {
+                    "stroke": 1.375,
+                    "radius": 12.75
+                  },
+                  "medium": {
+                    "stroke": 0.75,
+                    "radius": 12.75
+                  },
+                  "mini": {
+                    "stroke": 0.25,
+                    "radius": 10
+                  }
                 },
                 "reverse": true
               }

--- a/pages/_id.vue
+++ b/pages/_id.vue
@@ -72,7 +72,7 @@
       <BackgroundLayers
         id="page-singular-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -116,9 +116,19 @@ export default {
   data () {
     return {
       tag: 'blog',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -307,7 +317,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: 100%;
     background-color: $hawkesBlue;
-    border-radius: 14rem 0 0 14rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     z-index: -1;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     @include medium {
@@ -320,10 +330,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-radius: 5rem 0 0 5rem;
+      border-top-left-radius: 4.75rem;
     }
   }
 }
@@ -341,12 +348,6 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -14,7 +14,6 @@
       <BackgroundLayers
         id="page-about-background-layers"
         layers-array="3_4_5_6"
-        :print="true"
         :breakpoints="pageLayersBreakpointData" />
 
     </div>

--- a/pages/about.vue
+++ b/pages/about.vue
@@ -14,7 +14,8 @@
       <BackgroundLayers
         id="page-about-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :print="true"
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -46,9 +47,19 @@ export default {
   data () {
     return {
       tag: 'about',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -69,10 +80,6 @@ export default {
     }),
     sections () {
       const content = CloneDeep(this.siteContent.about.page_content)
-      // const len = content.length
-      // const last = content[len - 1]
-      // const replace = this.siteContent['section-dive-deeper'].concat(last)
-      // content.splice(len - 1, 1, replace)
       return content
     }
   }
@@ -125,19 +132,16 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: 100%;
     background-color: $hawkesBlue;
-    border-radius: 12.75rem 0 0 12.75rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-top-left-radius: 12.75rem;
+      border-top-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-top-left-radius: 5rem;
+      border-top-left-radius: 4.75rem;
     }
   }
 }
@@ -157,22 +161,19 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     top: 0.5rem;
     left: $backgroundLayers__Left__Desktop;
     width: calc(100% + 3.5rem);
-    height: calc(100% + 4rem);
+    height: calc(100% + 3.625rem);
     background-color: $polar;
-    border-radius: 5rem 0 0 13rem;
+    border-radius: 5rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-bottom-left-radius: 12rem;
+      border-bottom-left-radius: 11.75rem;
       height: calc(100% + 3.5rem);
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-bottom-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-bottom-left-radius: 5rem;
+      border-bottom-left-radius: 4.75rem;
     }
   }
 }
@@ -189,12 +190,6 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 

--- a/pages/basic-template-1.vue
+++ b/pages/basic-template-1.vue
@@ -14,7 +14,7 @@
       <BackgroundLayers
         id="page-basic-1-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -45,9 +45,19 @@ export default {
   data () {
     return {
       tag: 'basic-page-1',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },

--- a/pages/basic-template-2.vue
+++ b/pages/basic-template-2.vue
@@ -14,7 +14,7 @@
       <BackgroundLayers
         id="page-basic-2-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -45,9 +45,19 @@ export default {
   data () {
     return {
       tag: 'basic-page-2',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -119,19 +129,16 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: 100%;
     background-color: $hawkesBlue;
-    border-radius: 14rem 0 0 14rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-top-left-radius: 12.75rem;
+      border-top-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-radius: 5rem 0 0 5rem;
+      border-top-left-radius: 4.75rem;
     }
   }
 }
@@ -152,19 +159,16 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: calc(100% + 3.5rem);
     background-color: $polar;
-    border-radius: 5rem 0 0 13rem;
+    border-radius: 5rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-bottom-left-radius: 12rem;
+      border-bottom-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-bottom-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-bottom-left-radius: 5rem;
+      border-bottom-left-radius: 4.75rem;
     }
   }
 }
@@ -192,12 +196,6 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -31,7 +31,7 @@
       <BackgroundLayers
         id="page-blog-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -66,9 +66,19 @@ export default {
   data () {
     return {
       tag: 'blog',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -222,12 +232,6 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 

--- a/pages/ecosystem.vue
+++ b/pages/ecosystem.vue
@@ -14,7 +14,7 @@
       <BackgroundLayers
         id="page-ecosystem-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -46,9 +46,19 @@ export default {
   data () {
     return {
       tag: 'ecosystem',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -121,19 +131,16 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: 100%;
     background-color: $hawkesBlue;
-    border-radius: 14rem 0 0 14rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-top-left-radius: 12.75rem;
+      border-top-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-radius: 5rem 0 0 5rem;
+      border-top-left-radius: 4.75rem;
     }
   }
 }
@@ -152,21 +159,18 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     top: 0.5rem;
     left: $backgroundLayers__Left__Desktop;
     width: calc(100% + 3.5rem);
-    height: calc(100% + 4rem);
+    height: calc(100% + 3.5rem);
     background-color: $polar;
-    border-radius: 5rem 0 0 13rem;
+    border-radius: 5rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-bottom-left-radius: 12rem;
+      border-bottom-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-bottom-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-bottom-left-radius: 5rem;
+      border-bottom-left-radius: 4.75rem;
     }
   }
 }
@@ -194,12 +198,6 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 

--- a/pages/filaustin.vue
+++ b/pages/filaustin.vue
@@ -179,7 +179,7 @@ $indentedFill__Left: calc(50% - (#{$containerWidth} / 2) + (14 * 1.75rem));
     height: calc(100% + 4rem);
     border-bottom-left-radius: 11.375rem;
     @include mini {
-      border-bottom-left-radius: 4.75rem; 
+      border-bottom-left-radius: 4.75rem;
     }
   }
 }

--- a/pages/filaustin.vue
+++ b/pages/filaustin.vue
@@ -12,13 +12,13 @@
       <BackgroundLayers
         id="page-filaustin-body-layer"
         layers-array="2"
-        :offset="{ mini: 0.25 }" />
+        :breakpoints="{ mini: { stroke: 0.25, radius: 12.75 } }" />
 
       <BackgroundLayers
         id="page-filaustin-background-layers"
         layers-array="6_5_4_3"
         :reverse="true"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -49,9 +49,15 @@ export default {
       tag: 'filaustin',
       scroll: false,
       resize: false,
-      pageBackgroundLayersOffset: {
-        medium: 0.5,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        medium: {
+          stroke: 0.5,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -109,7 +115,7 @@ $indentedFill__Left: calc(50% - (#{$containerWidth} / 2) + (14 * 1.75rem));
     width: calc(100% + 3.5rem);
     height: calc(100% + 4.5rem + #{2.5 * $backgroundLayers__Offset});
     background-color: $blackPearl;
-    border-radius: 0 0 0 8.5rem;
+    border-radius: 0 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
   }
@@ -170,7 +176,11 @@ $indentedFill__Left: calc(50% - (#{$containerWidth} / 2) + (14 * 1.75rem));
 
 #section_6 {
   &:before {
-    height: calc(100% + 5.25rem + 2px);
+    height: calc(100% + 4rem);
+    border-bottom-left-radius: 11.375rem;
+    @include mini {
+      border-bottom-left-radius: 4.75rem; 
+    }
   }
 }
 

--- a/pages/get-involved.vue
+++ b/pages/get-involved.vue
@@ -14,7 +14,7 @@
       <BackgroundLayers
         id="page-get-involved-background-layers"
         layers-array="5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -45,9 +45,19 @@ export default {
   data () {
     return {
       tag: 'get_involved',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },

--- a/pages/governance.vue
+++ b/pages/governance.vue
@@ -12,13 +12,13 @@
       <BackgroundLayers
         id="page-governance-body-layer"
         layers-array="2"
-        :offset="{ mini: 0.25 }" />
+        :breakpoints="{ mini: { stroke: 0.25, radius: 5 } }" />
 
       <BackgroundLayers
         id="page-governance-background-layers"
         layers-array="6_5_4_3"
         :reverse="true"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -49,9 +49,15 @@ export default {
       tag: 'governance',
       scroll: false,
       resize: false,
-      pageBackgroundLayersOffset: {
-        medium: 0.5,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        medium: {
+          stroke: 0.5,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -165,8 +171,9 @@ $indentedFill__Left: calc(50% - (#{$containerWidth} / 2) + (14 * 1.75rem));
 #section_7 {
   &:before {
     border-radius: 0 0 0 8.5rem;
+    height: calc(100% + 4rem);
     @include mini {
-      border-radius: 0 0 0 10rem;
+      border-radius: 0 0 0 4.75rem;
     }
   }
 }

--- a/pages/grants.vue
+++ b/pages/grants.vue
@@ -161,14 +161,14 @@ export default {
   }
   .image {
     width: 50vw;
-    border-radius: 25vw 3rem 3rem 25vw;
+    max-width: 858px;
+    border-radius: 11.375rem 0rem 0rem 11.375rem;
     filter: drop-shadow(5px 5px 5px rgba(0, 0, 0, 0.15));
     @include small {
       width: 100vw;
-      border-radius: 40vw 3rem 3rem 40vw;
     }
     @include mini {
-      border-radius: 50vw 3rem 3rem 50vw;
+      border-radius: 4.25rem 0rem 0rem 4.25rem;
     }
   }
   [class~="grid"], [class*="grid-"], [class*="grid_"] {
@@ -342,6 +342,11 @@ export default {
   }
   @include mini {
     padding-top: 3rem;
+  }
+  .background-layers {
+    @include mini {
+      left: -3rem;
+    }
   }
 }
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -14,7 +14,7 @@
       <BackgroundLayers
         id="page-index-background-layers"
         layers-array="2_3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -46,9 +46,19 @@ export default {
   data () {
     return {
       tag: 'index',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        default: {
+          stroke: 1.375,
+          radius: 12.75
+        },
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -125,19 +135,16 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: 100%;
     background-color: $polar;
-    border-radius: 14rem 0 0 5rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-top-left-radius: 12rem;
+      border-top-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-top-left-radius: 5rem;
+      border-top-left-radius: 4.75rem;
     }
   }
 }
@@ -159,19 +166,16 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     width: calc(100% + 3.5rem);
     height: calc(100% + 4rem);
     background-color: $polar;
-    border-radius: 5rem 0 0 13rem;
+    border-radius: 5rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: -1;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-bottom-left-radius: 12rem;
+      border-bottom-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-bottom-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-bottom-left-radius: 5rem;
+      border-bottom-left-radius: 4.75rem;
     }
   }
 }
@@ -188,12 +192,6 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 
@@ -404,6 +402,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
     @include small {
       top: -2rem;
       left: 0.5rem;
+      height: calc(100% + 4rem);
     }
     @include mini {
       left: -2rem;

--- a/pages/policy.vue
+++ b/pages/policy.vue
@@ -90,7 +90,7 @@
       <BackgroundLayers
         id="page-policy-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -114,9 +114,15 @@ export default {
   data () {
     return {
       tag: 'policy',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -208,20 +214,16 @@ ul {
     width: calc(100% + 3.5rem);
     height: calc(100% + 5.5rem);
     background-color: $hawkesBlue;
-    border-radius: 12.75rem 0 0 12.75rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: 0;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-top-left-radius: 12.75rem;
+      border-top-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-      border-bottom-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-top-left-radius: 5rem;
+      border-top-left-radius: 4.75rem;
       border-bottom-left-radius: 4.75rem;
     }
   }
@@ -239,12 +241,6 @@ ul {
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 </style>

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -60,7 +60,7 @@
       <BackgroundLayers
         id="page-terms-background-layers"
         layers-array="3_4_5_6"
-        :offset="pageBackgroundLayersOffset" />
+        :breakpoints="pageLayersBreakpointData" />
 
     </div>
 
@@ -84,9 +84,15 @@ export default {
   data () {
     return {
       tag: 'terms',
-      pageBackgroundLayersOffset: {
-        medium: 1,
-        mini: 0.25
+      pageLayersBreakpointData: {
+        medium: {
+          stroke: 1,
+          radius: 12.75
+        },
+        mini: {
+          stroke: 0.25,
+          radius: 5
+        }
       }
     }
   },
@@ -168,20 +174,16 @@ p a {
     width: calc(100% + 3.5rem);
     height: calc(100% + 5.5rem);
     background-color: $hawkesBlue;
-    border-radius: 12.75rem 0 0 12.75rem;
+    border-radius: 11.375rem 0 0 11.375rem;
     filter: drop-shadow(0 0 0.4rem rgba(0, 0, 0, 0.1));
     z-index: 0;
     @include medium {
       left: $backgroundLayers__Left__Medium;
-      border-top-left-radius: 12.75rem;
+      border-top-left-radius: 11.75rem;
     }
     @include mini {
       left: $backgroundLayers__Left__Mini;
-      border-top-left-radius: 10.75rem;
-      border-bottom-left-radius: 10.75rem;
-    }
-    @include tiny {
-      border-top-left-radius: 5rem;
+      border-top-left-radius: 4.75rem;
       border-bottom-left-radius: 4.75rem;
     }
   }
@@ -199,12 +201,6 @@ p a {
   }
   @include mini {
     left: $backgroundLayers__Left__Mini;
-  }
-  @include tiny {
-    .layer {
-      border-top-left-radius: 5rem !important;
-      border-bottom-left-radius: 5rem !important;
-    }
   }
 }
 </style>


### PR DESCRIPTION
A refactor to the way border radii are applied to page/component layers. Previously, the BackgroundLayers component's function for calculating sequential border radii was being over-ridden at small breakpoints in the scss. This refactor adds the ability to change border radius according to breakpoint in the BackgroundLayers component itself, in the same way the layer width is set by breakpoint. Relevant scss has been removed.

Old structure for the BackgroundLayers component offset prop:

```
"offset": {
  "medium": 1,
  "mini": 0.25
}
```

New structure (prop renamed to breakpoints):

```
"breakpoints": {
      "default": {
         "stroke": 1.375,
         "radius": 12.75
       },
       "medium": {
          "stroke": 0.75,
           "radius": 12.75
        },
        "mini": {
           "stroke": 0.25,
           "radius": 10
        }
     }
```

Where `stroke` sets the layers' stroke width at that breakpoint and `radius` sets the border-radius.