### PR TITLE
feat: adding descriptions to fields in yaml files that are connected to forestry

### DIFF
--- a/.forestry/front_matter/templates/background-layers.yml
+++ b/.forestry/front_matter/templates/background-layers.yml
@@ -7,6 +7,7 @@ fields:
   config:
     required: false
   label: Type
+  description: 'Do not change. This field is only visible to Forestry admins.'
   hidden: true
   default: custom
 - name: component
@@ -14,6 +15,7 @@ fields:
   config:
     required: false
   label: Component
+  description: 'Do not change. This field is only visible to Forestry admins.'
   hidden: true
   default: BackgroundLayers
 - name: props
@@ -27,6 +29,7 @@ fields:
       min: 
       max: 
     label: Layers Array
+    description: 'Do not change. This field is only visible to Forestry admins.'
   - name: offset
     type: field_group
     config: {}
@@ -34,7 +37,7 @@ fields:
     - name: large
       type: number
       label: Large
-      description: ''
+      description: 'Do not change. This field is only visible to Forestry admins.'
       default: 0
       required: true
       config:
@@ -44,7 +47,7 @@ fields:
     - name: medium
       type: number
       label: Medium
-      description: ''
+      description: 'Do not change. This field is only visible to Forestry admins.'
       default: 0
       required: true
       config:
@@ -54,7 +57,7 @@ fields:
     - name: small
       type: number
       label: Small
-      description: ''
+      description: 'Do not change. This field is only visible to Forestry admins.'
       default: 0
       required: true
       config:
@@ -64,7 +67,7 @@ fields:
     - name: mini
       type: number
       label: Mini
-      description: ''
+      description: 'Do not change. This field is only visible to Forestry admins.'
       default: 0
       required: true
       config:
@@ -74,7 +77,7 @@ fields:
     - name: tiny
       type: number
       label: Tiny
-      description: ''
+      description: 'Do not change. This field is only visible to Forestry admins.'
       default: 0
       required: true
       config:
@@ -82,13 +85,15 @@ fields:
         max: 
         step: 
     label: Layer Offsets
+    description: 'Do not change. This field is only visible to Forestry admins.'
   - name: reverse
     type: boolean
     label: Reverse
+    description: 'Do not change. This field is only visible to Forestry admins.'
   - name: borderRadius
     type: number
     label: Border Radius
-    description: ''
+    description: 'Do not change. This field is only visible to Forestry admins.'
     default: 0
     required: true
     config:
@@ -109,6 +114,7 @@ fields:
         file: 
         path: 
     label: Border Radius Direction
+    description: 'Do not change. This field is only visible to Forestry admins.'
   - name: shadowStrength
     type: select
     default: []
@@ -123,4 +129,6 @@ fields:
         file: 
         path: 
     label: Shadow Strength
+    description: 'Do not change. This field is only visible to Forestry admins.'
   label: Properties
+  description: 'Do not change. This field is only visible to Forestry admins.'

--- a/.forestry/front_matter/templates/block-image.yml
+++ b/.forestry/front_matter/templates/block-image.yml
@@ -14,13 +14,16 @@ fields:
   config: {}
   template: layout-columns
   label: Columns
+  description: 'DO NOT EDIT'
 - name: label
   type: text
   config:
     required: false
   label: Label
+  description: 'DO NOT EDIT'
 - name: src
   type: file
   config:
     maxSize: 64
   label: Image
+  description: 'Add an image that will appear in this section'

--- a/.forestry/front_matter/templates/block-video.yml
+++ b/.forestry/front_matter/templates/block-video.yml
@@ -7,6 +7,7 @@ fields:
   config:
     required: false
   label: Type
+  description: 'DO NOT EDIT'
   hidden: true
   default: video_block
 - name: cols
@@ -14,17 +15,21 @@ fields:
   config: {}
   template: layout-columns
   label: Columns
+  description: 'DO NOT EDIT'
 - name: url
   type: text
   config:
     required: false
   label: URL
+  description: 'Paste video URL here'
 - name: preview_image
   type: file
   config:
     maxSize: 64
   label: Image
+  description: 'Add a still image that will be a preview image for video '
 - name: tint
   type: boolean
   label: Tint
+  description: 'Click toggle on to put darker blue overlay over preview image - toggle is green when blue tint is present and grey when it is not'
   default: true

--- a/.forestry/front_matter/templates/button.yml
+++ b/.forestry/front_matter/templates/button.yml
@@ -7,6 +7,7 @@ fields:
   config:
     required: false
   label: Text
+  description: 'The button's text
 - name: type
   type: select
   default: []
@@ -27,6 +28,7 @@ fields:
       file: 
       path: 
   label: Type
+  description: 'Select the buttons style type from the dropdown menu. (A) → traditional button with blue gradient edges, choose light in theme to get white button with blue gradient border (ex. "Learn More" button on Home page) or dark in theme to get dark blue button with dark blue gradient border (ex. "Learn More" button on Grants page") |  (B) → transparent button with white border and white text (ex. "Watch Video" button on Home page)  |(D) → No button styling, only blue text (ex. "Watch: Meet the Filecoin Foundation" on About page )  |(F) → No button styling, only text in either light-themed or dark-themed - light is white (ex. "Terms of Use" and "Data and Privacy" in footer) and dark (ex. "Future Rules Podcast" in footer) is blue  |(G) →  Reserved for "Events and Hackathons" navigation'
 - name: action
   type: select
   default: []
@@ -43,6 +45,7 @@ fields:
       file: 
       path: 
   label: Action
+  description: 'Select "Link" to link to a page outside of the site and "Nuxt-link" to link to an internal page. "Button" is reserved for advanced functionality. "Video" will open a video modal and play video'
 - name: theme
   type: select
   default: []
@@ -57,11 +60,13 @@ fields:
       file: 
       path: 
   label: Theme
+  description: 'Select color of button. Light theme shows a light blue border around button and white background (ex.  "Join the community" button found on About page) and dark theme shows dark blue border around button with blue background (ex. "Learn More" button found on Grants page)'
 - name: url
   type: text
   config:
     required: false
   label: URL
+  description: 'Enter the link that the user is taken to, when the button is clicked. If using "Link", URL should be external page URL, if using "Nuxt-link" use an internal path such as "/about"  or "/if user is directed to About page'
 - name: icon
   type: select
   default: []
@@ -80,3 +85,4 @@ fields:
       file: 
       path: 
   label: Icon
+  description: 'Select the icon that will appear to left of button text'

--- a/.forestry/front_matter/templates/card.yml
+++ b/.forestry/front_matter/templates/card.yml
@@ -19,10 +19,11 @@ fields:
       file: 
       path: 
   label: Card Type
+  decription: 'Select one type : (A) -> stacked vertically beginning with an image, a title and a descrption (ex. on Grants page, list of types of grants) |  (B) - > image with title below and on hover, image slides up to reveal description (ex. Board of Directors section on About page) |  (C) - >  card has image on left and description on right (ex. on About page , Advisors section)  |  ( D) - > stacked vertically beginning with image and date , title and a button (ex. Events and Hackathons section on Governance page) '
 - name: date
   type: datetime
   label: Date
-  description: ''
+  description: 'Select date. Date will display above title if included'
   config:
     required: false
     date_format: 
@@ -33,11 +34,13 @@ fields:
   config:
     required: false
   label: Label
+  description: 'DO NOT EDIT'
 - name: title
   type: text
   config:
     required: false
   label: Title
+  description: 'Title for card content'
 - name: description
   type: textarea
   default: ''
@@ -47,11 +50,13 @@ fields:
     schema:
       format: markdown
   label: Description
+  description: 'Main text content of card'
 - name: img
   type: file
   config:
     maxSize: 64
   label: Image
+  description: 'Choose the image displayed in the card'
 - name: img_type
   type: select
   default: []
@@ -67,6 +72,8 @@ fields:
       file: 
       path: 
   label: Image Type
+  description: 'Choose if image is a regular image, a larger background image (ex. images on cards on Events page), or if image will also be a link to other internal pages'
+  hidden: true
 - name: img_size
   type: select
   default: []
@@ -82,6 +89,8 @@ fields:
       file: 
       path: 
   label: Image Size
+  description: 'Choose is image will be Full (takes up 100% of space available) , Regular, or Mini (image will be small)'
+  hidden: true
 - name: action
   type: select
   default: []
@@ -96,16 +105,19 @@ fields:
       file: 
       path: 
   label: Action
+  description: 'Select "a" to link to a page outside of the site and "nuxt-link" to link to an internal page'
 - name: url
   type: text
   config:
     required: false
   label: URL
+  description: 'Enter the link that the user is taken to, when the button is clicked. If using "Link", URL should be external page URL, if using "Nuxt-link" use an internal path such as "/about"  or "/if user is directed to About page'
 - name: target
   type: text
   config:
     required: false
   label: Target
+  description: 'Do not change. This field is only visible to Forestry admins.'
   hidden: true
   default: _blank
 - name: cta
@@ -118,3 +130,4 @@ fields:
     template: button
     label: CTA
   label: CTA
+  description: 'Click "Add CTA" to add and populate a button in the card'

--- a/.forestry/front_matter/templates/columns.yml
+++ b/.forestry/front_matter/templates/columns.yml
@@ -11,9 +11,11 @@ fields:
     config:
       required: false
     label: Number
+    description: 'Number of columns'
   - name: push_left
     type: text
     config:
       required: false
     label: Push Left
+    description: 'Columns that will be pushed left'
   label: Columns

--- a/.forestry/front_matter/templates/comp-divedeeper.yml
+++ b/.forestry/front_matter/templates/comp-divedeeper.yml
@@ -1,10 +1,11 @@
 ---
 label: "[Comp] DiveDeeper"
+description: 'Video testimonials and accompanying text'
 hide_body: true
 fields:
 - type: field_group
   name: dive_deeper
-  label: dive_deeper
+  label: Dive Deeper
   fields:
   - type: text
     name: type
@@ -20,8 +21,8 @@ fields:
     default: DiveDeeper
   - type: field_group
     name: props
-    label: props
-    description: 'Page Content'
+    label: Content
+    description: 'Dive Deeper content is editable within this section.'
     fields:
     - type: field_group
       name: intro

--- a/.forestry/front_matter/templates/comp-divedeeper.yml
+++ b/.forestry/front_matter/templates/comp-divedeeper.yml
@@ -9,16 +9,19 @@ fields:
   - type: text
     name: type
     label: type
+    description: 'Do not change. This field is only visible to Forestry admins.'
     hidden: true
     default: custom
   - type: text
     name: component
     label: component
+    description: 'Do not change. This field is only visible to Forestry admins.'
     hidden: true
     default: DiveDeeper
   - type: field_group
     name: props
     label: props
+    description: 'Page Content'
     fields:
     - type: field_group
       name: intro
@@ -27,49 +30,60 @@ fields:
       - type: field_group
         name: cols
         label: cols
+        description: 'DO NOT CHANGE'
         fields:
         - type: text
           name: num
           label: num
+          description: 'Do not change. This field is only visible to Forestry admins.'
           hidden: true
           default: col-7_sm-8_mi-9_ti-10
         - type: text
           name: push_left
           label: push_left
+          description: 'Do not change. This field is only visible to Forestry admins.'
           hidden: true
           default: off-1_sm-2_mi-1
         hidden: true
       - type: text
         name: heading
         label: heading
+        description: 'Add heading text here'
       - type: textarea
         name: subheading
         label: subheading
+        description: 'Add subheading text here'
     - type: field_group_list
       name: videos
       label: videos
+      description: 'Click Add Video to add a new video'
       fields:
       - type: field_group
         name: left
         label: Left Block
+        description: 'DO NOT CHANGE'
         fields:
         - type: text
           name: type
           label: type
           hidden: true
+          description: 'Do not change. This field is only visible to Forestry admins.'
           default: video_block
         - type: field_group
           name: cols
           label: cols
+          description: 'DO NOT CHANGE'
           fields:
           - type: text
             name: num
             label: num
+            description: 'Do not change. This field is only visible to Forestry admins.'
             default: col-6_sm-8_mi-9_ti-11
             hidden: true
           - type: text
             name: push_left
             label: push_left
+            description: 'Do not change. This field is only visible to Forestry admins.'
             hidden: true
             default: off-1_sm-2_mi-1
           hidden: true
@@ -80,40 +94,49 @@ fields:
           - type: file
             name: preview_image
             label: preview image
+            description: 'Add a still image that will be a preview image for video '
           - type: text
             name: url
             label: url
+            description: 'input video URL'
       - type: field_group
         name: right
         label: Right Block
+        description: 'DO NOT CHANGE'
         fields:
         - type: text
           name: type
           label: type
+          description: 'Do not change. This field is only visible to Forestry admins.'
           hidden: true
           default: text_block
         - type: field_group
           name: cols
           label: cols
+          description: 'DO NOT CHANGE'
           fields:
           - type: text
             name: num
             label: num
+            description: 'Do not change. This field is only visible to Forestry admins.'
             hidden: true
             default: col-4_sm-8_mi-9_ti-11
           - type: text
             name: push_left
             label: push_left
+            description: 'Do not change. This field is only visible to Forestry admins.'
             hidden: true
             default: off-1_sm-2_mi-1
           hidden: true
         - type: field_group
           name: props
           label: props
+          description: 'DO NOT CHANGE'
           fields:
           - type: text
             name: layout
             label: layout
+            description: 'Do not change. This field is only visible to Forestry admins.'
             hidden: true
             default: medium
           - type: field_group_list
@@ -123,34 +146,42 @@ fields:
             - type: text
               name: type
               label: type
+              description: 'Do not change. This field is only visible to Forestry admins.'
               hidden: true
               default: B
             - type: text
               name: theme
               label: theme
+              description: 'Do not change. This field is only visible to Forestry admins.'
               hidden: true
               default: dark
             - type: text
               name: action
               label: action
+              description: 'Do not change. This field is only visible to Forestry admins.'
               hidden: true
               default: video
             - type: text
               name: icon
               label: icon
+              description: 'Do not change. This field is only visible to Forestry admins.'
               hidden: true
               default: icon
             - type: text
               name: text
               label: text
+              description: 'Add text here'
             - type: text
               name: url
               label: url
+              description: 'Add URL here'
             config:
               max: 1
           - type: text
             name: heading
             label: heading
+            description: 'Add heading text here'
           - type: textarea
             name: description
             label: description
+            description: 'Add description text here'

--- a/.forestry/front_matter/templates/comp-slider-block.yml
+++ b/.forestry/front_matter/templates/comp-slider-block.yml
@@ -7,6 +7,7 @@ fields:
   config:
     required: false
   label: Type
+  description: 'Do not change. This field is only visible to Forestry admins.'
   hidden: true
   default: slider_block
 - name: cols
@@ -14,9 +15,11 @@ fields:
   config: {}
   template: layout-columns
   label: Columns
+  description: 'DO NOT CHANGE'
 - name: cards
   type: blocks
   label: Cards
+  description: 'Add a card here'
   template_types:
   - card
   config:

--- a/.forestry/front_matter/templates/data-open-graph-social.yml
+++ b/.forestry/front_matter/templates/data-open-graph-social.yml
@@ -11,19 +11,23 @@ fields:
     config:
       required: false
     label: Site Name
+    description: 'Name of the site.'
   - name: url
     type: text
     config:
       required: false
     label: URL
+    description: 'The page's full URL/path.'
   - name: type
     type: text
     config:
       required: false
     label: Type
+    description: The social metadata page or content type. In most cases this will be website or article. See open graph types, for everything available in the spec.
   - name: image
     type: file
     config:
       maxSize: 64
     label: Image
+    description: Upload an image to appear in social previews for this page.
   label: Open Graph & Social

--- a/.forestry/front_matter/templates/data-seo.yml
+++ b/.forestry/front_matter/templates/data-seo.yml
@@ -11,7 +11,7 @@ fields:
     config:
       required: false
     label: Title
-    description: Test 123
+    description: The title for this web page
   - name: description
     type: text
     config:
@@ -19,4 +19,4 @@ fields:
     label: Description
     description: Test 234
   label: SEO
-  description: Let's do SEO!
+  description: The meta description for this page, which will appear in search engine results and social media previews. Each page can have a unique meta description. One to three sentences are recommended.

--- a/.forestry/front_matter/templates/data-seo.yml
+++ b/.forestry/front_matter/templates/data-seo.yml
@@ -11,9 +11,12 @@ fields:
     config:
       required: false
     label: Title
+    description: Test 1
   - name: description
     type: text
     config:
       required: false
     label: Description
+    description: Test 2
   label: SEO
+  description: Here it goes

--- a/.forestry/front_matter/templates/data-seo.yml
+++ b/.forestry/front_matter/templates/data-seo.yml
@@ -11,12 +11,12 @@ fields:
     config:
       required: false
     label: Title
-    description: Test 1
+    description: Test 123
   - name: description
     type: text
     config:
       required: false
     label: Description
-    description: Test 2
+    description: Test 234
   label: SEO
-  description: Here it goes
+  description: Let's do SEO!

--- a/.forestry/front_matter/templates/events-hackathons.yml
+++ b/.forestry/front_matter/templates/events-hackathons.yml
@@ -58,7 +58,7 @@ fields:
     - name: cards
       type: blocks
       label: Cards
-      description: 'Add acard'
+      description: 'Add a card'
       template_types:
       - card
       config:

--- a/.forestry/front_matter/templates/events-hackathons.yml
+++ b/.forestry/front_matter/templates/events-hackathons.yml
@@ -7,6 +7,7 @@ fields:
   config:
     required: false
   label: Type
+  description: 'Do not change. This field is only visible to Forestry admins.'
   hidden: true
   default: custom
 - name: component
@@ -15,6 +16,7 @@ fields:
     required: false
   label: Component
   hidden: true
+  description: 'Do not change. This field is only visible to Forestry admins.'
   default: EventsHackathons
 - name: props
   type: field_group
@@ -29,16 +31,19 @@ fields:
       config: {}
       template: layout-columns
       label: Columns
+      description: 'DO NOT EDIT'
     - name: heading
       type: text
       config:
         required: false
       label: Heading
+      description: 'Add heading text here'
     - name: cta
       type: include
       config: {}
       template: button
       label: CTA
+      description: 'Click 'Add a CTA' to add a button'
     label: Intro
   - name: events
     type: field_group
@@ -49,9 +54,11 @@ fields:
       config: {}
       template: layout-columns
       label: Columns
+      description: 'DO NOT EDIT'
     - name: cards
       type: blocks
       label: Cards
+      description: 'Add acard'
       template_types:
       - card
       config:

--- a/.forestry/front_matter/templates/grid-classes.yml
+++ b/.forestry/front_matter/templates/grid-classes.yml
@@ -26,3 +26,4 @@ fields:
     - equalHeight
     - noBottom
   label: Grid Classes
+  description: 'Changes CSS classes. DO NOT EDIT'

--- a/.forestry/front_matter/templates/layout-columns.yml
+++ b/.forestry/front_matter/templates/layout-columns.yml
@@ -11,14 +11,18 @@ fields:
     config:
       required: false
     label: Number
+    description: 'Number of columns total. DO NOT EDIT.'
   - name: push_left
     type: text
     config:
       required: false
     label: Push Left
+    description: 'Columns that will be pushed to left. DO NOT EDIT.'
   - name: push_right
     type: text
     config:
       required: false
     label: Push Right
+    description: 'Columns that will be pushed to right. DO NOT EDIT.'
   label: Columns
+  description: 'Columns in layout'

--- a/.forestry/front_matter/templates/layout.yml
+++ b/.forestry/front_matter/templates/layout.yml
@@ -17,3 +17,4 @@ fields:
       file: 
       path: 
   label: "[Comp] Layout"
+  description: 'DO NOT EDIT'

--- a/.forestry/front_matter/templates/page-about.yml
+++ b/.forestry/front_matter/templates/page-about.yml
@@ -187,6 +187,7 @@ fields:
           template: block-text
           label: Template → [Block] Text
         label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: panel_1_cards
       label: Panel 1 Cards

--- a/.forestry/front_matter/templates/page-about.yml
+++ b/.forestry/front_matter/templates/page-about.yml
@@ -7,6 +7,7 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
@@ -15,6 +16,7 @@ fields:
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
@@ -22,6 +24,7 @@ fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First section on page'
       fields:
       - name: left
         type: field_group
@@ -172,6 +175,7 @@ fields:
     - type: field_group
       name: panel_1_cards
       label: Panel 1 Cards
+      description: 'Slider with Board of Directors'
       fields:
       - type: field_group
         name: left
@@ -196,6 +200,7 @@ fields:
         config: {}
         template: grid-classes
         label: Template → [Layout] Grid Alignment
+        description: 'CSS Grid Classes. DO NOT EDIT'
       - name: left
         type: field_group
         config: {}

--- a/.forestry/front_matter/templates/page-about.yml
+++ b/.forestry/front_matter/templates/page-about.yml
@@ -13,6 +13,7 @@ fields:
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
@@ -20,11 +21,13 @@ fields:
   fields:
   - type: field_group
     name: section_1
+    label: Section 1
+    description: 'This begins at the top of the page and ends before 'Advisors' section (at the end of solid white background).'
     fields:
     - type: field_group
       name: hero
       label: Hero
-      description: 'First section on page'
+      description: 'First content section on page'
       fields:
       - name: left
         type: field_group
@@ -35,7 +38,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
       - name: right
         type: field_group
         config: {}
@@ -45,7 +49,8 @@ fields:
           config: {}
           template: block-video
           label: Template → [Block] Video
-        label: Right Block
+        label: Right Column
+        description: 'Video block is editable within this section.'
     - type: field_group
       name: intro_1
       fields:
@@ -58,11 +63,13 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
       label: Intro 1
     - type: field_group
       name: cta_1
       label: CTA 1
+      description: 'Text block and image. The image is on the left side and the text block is on the right.'
       fields:
       - name: left
         type: field_group
@@ -73,7 +80,8 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Left Block
+        label: Left Column 
+        description: 'The image block is editable within this section'
       - name: right
         type: field_group
         config: {}
@@ -83,14 +91,17 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Right Block
+        label: Right Column
+        description: 'The text block is editable within this section.'
     - type: field_group
       name: banner_1
       label: Banner 1
+      description: 'Text within gradient on dark blue background'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'The text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -138,6 +149,7 @@ fields:
     - type: field_group
       name: cta_2
       label: CTA 2
+      description: 'Textblock on left and image on right.'
       fields:
       - name: left
         type: field_group
@@ -148,10 +160,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'The image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -161,6 +175,7 @@ fields:
     - type: field_group
       name: panel_1
       label: Panel 1
+      description: 'Text block that is above slider cards on light blue background.'
       fields:
       - name: left
         type: field_group
@@ -171,15 +186,16 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
     - type: field_group
       name: panel_1_cards
       label: Panel 1 Cards
-      description: 'Slider with Board of Directors'
+      description: 'Slider cards that are below text block.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Slider cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -190,10 +206,12 @@ fields:
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This is the 'Advisors' section with image cards on right side on dark blue background.'
     fields:
     - type: field_group
       name: explore_1
-      label: Explore 1
+      label: Content
+      description: ''
       fields:
       - name: grid
         type: include
@@ -210,10 +228,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        descriptiin: 'Image cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -272,12 +292,14 @@ fields:
           hidden: true
   - type: field_group
     name: section_3
+    label: Section 3
+    description: 'This section begins after 'Advisors' section, ends at the footer, and has a solid white background.'
     fields:
     - name: diver_deeper
       type: include
       config: {}
       template: comp-divedeeper
       label: Template → [Comp] DiveDeeper
-    label: Section 3
+      description: 'Video testimonials and accompanying text'
 pages:
 - content/pages/about.json

--- a/.forestry/front_matter/templates/page-basic-template-1.yml
+++ b/.forestry/front_matter/templates/page-basic-template-1.yml
@@ -22,7 +22,7 @@ fields:
   - type: field_group
     name: section_1
     label: Section 1
-    description: 'The begins at the top of the page and contains a textblock and image on a royal blue background. The text block is on the left and the image block is on the right.'
+    description: 'The section begins at the top of the page and contains a textblock and image on a royal blue background. The text block is on the left and the image block is on the right.'
     fields:
     - type: field_group
       name: basic_hero
@@ -56,6 +56,7 @@ fields:
         label: Right Column
         description: 'The image block is editable within this section'
       label: Basic Hero
+
   - type: field_group
     name: section_2
     label: Section 2
@@ -127,7 +128,7 @@ fields:
     - type: field_group
       name: panels_1
       label: Panels 1
-      description: 'Text block on left and image on right.'
+      description: 'Text block on left and image on right on light blue background.'
       fields:
       - name: left
         type: field_group

--- a/.forestry/front_matter/templates/page-basic-template-1.yml
+++ b/.forestry/front_matter/templates/page-basic-template-1.yml
@@ -7,18 +7,22 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
     label: Section 1
+    description: 'The begins at the top of the page and contains a textblock and image on a royal blue background. The text block is on the left and the image block is on the right.'
     fields:
     - type: field_group
       name: basic_hero
@@ -28,6 +32,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -37,7 +42,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'The text block is editable within this section'
       - name: right
         type: field_group
         config: {}
@@ -47,15 +53,18 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Right Block
+        label: Right Column
+        description: 'The image block is editable within this section'
       label: Basic Hero
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This section contains images and text on a light blue background.'
     fields:
     - type: field_group
       name: basic_content_1
       label: Basic Content 1
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -71,10 +80,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: banner_image
       label: Banner Image
+      description: 'Image block that is positioned under text block.'
       fields:
       - type: text
         name: classNames
@@ -90,10 +101,12 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Left Block
+        label: Content
+        description: 'Image block is editable within this section.'
     - type: field_group
       name: basic_content_2
       label: Basic Content 2
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -109,10 +122,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: panels_1
       label: Panels 1
+      description: 'Text block on left and image on right.'
       fields:
       - name: left
         type: field_group
@@ -123,7 +138,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
       - name: right
         type: field_group
         config: {}
@@ -133,10 +149,12 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Right Block
+        label: Right Column
+        description: 'Image block is editable within this section.'
     - type: field_group
       name: basic_content_3
       label: Basic Content 3
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -152,7 +170,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: basic_content_4
       fields:
@@ -170,11 +189,14 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
       label: Basic Content 4
+      description: 'Text block on light blue background.'
     - type: field_group
       name: basic_content_5
       label: Basic Content 5
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -190,10 +212,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section contains the Events and Hackathons section and ends at the footer.'
     fields:
     - name: events_hackathons
       type: include

--- a/.forestry/front_matter/templates/page-basic-template-2.yml
+++ b/.forestry/front_matter/templates/page-basic-template-2.yml
@@ -7,28 +7,35 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
     label: Section 1
+    description: 'This section begins at the top of the page until the end of the light blue background.'
     fields:
     - type: field_group
       name: basic_hero
       label: Basic Hero
+      description: 'First content section on page with a textblock on the left and an image block on the right.'
+      description: ''
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -38,7 +45,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'The textblock is editable within this section'
       - name: right
         type: field_group
         config: {}
@@ -48,14 +56,17 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Right Block
+        label: Right Column
+        description: 'The image block is editable within this section'
     - type: field_group
       name: intro_1
       label: Intro 1
+      description: 'Textblock within blue gradient and dark blue background'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Textblock is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -107,6 +118,7 @@ fields:
     - type: field_group
       name: cta_banner_1
       label: CTA Banner 1
+      description: 'Image block and textblock. The image block on the left and textblock is on the right.'
       fields:
       - type: text
         name: classNames
@@ -118,6 +130,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -127,7 +140,8 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Left Block
+        label: Left Column
+        description: 'The immage is editable within this section.'
       - name: right
         type: field_group
         config: {}
@@ -137,10 +151,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Right Block
+        label: Right Column
+        description: 'The text block is editable within this section.'
     - type: field_group
       name: basic_content_1
       label: Basic Content 1
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -156,10 +172,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: basic_content_2
       label: Basic Content 2
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -175,10 +193,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: basic_content_3
       label: Basic Content 3
+      description: 'Text block on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -194,10 +214,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: panels_1
       label: Panels 1
+      description: 'Text block on left and image on right on light blue background.'
       fields:
       - type: text
         name: classNames
@@ -209,6 +231,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -218,7 +241,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
       - name: right
         type: field_group
         config: {}
@@ -228,10 +252,12 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Right Block
+        label: Right Column
+        description: 'Image block is editable within this section.'
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This section is the 'Participation' or 'Resources' section where there is a text block on the left on a sky blue background and clickable cards on the right with a dark blue background.'
     fields:
     - type: field_group
       name: resources
@@ -242,6 +268,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -251,10 +278,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'The text block is editable within this section.'
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Clickable cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -301,11 +330,13 @@ fields:
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section begins after 'Participation' section, ends at the footer, and has a solid white background.'
     fields:
     - name: dive_deeper
       type: include
       config: {}
       template: comp-divedeeper
       label: Template → [Comp] Diver Deeper
+      description: 'Video testimonials and accompanying text'
 pages:
 - content/pages/basic-template-2.json

--- a/.forestry/front_matter/templates/page-ecosystem.yml
+++ b/.forestry/front_matter/templates/page-ecosystem.yml
@@ -7,6 +7,7 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
@@ -15,6 +16,7 @@ fields:
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
@@ -23,12 +25,14 @@ fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First section on page'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Changes CSS Classes. DO NOT EDIT'
       - name: left
         type: field_group
         config: {}
@@ -168,6 +172,7 @@ fields:
     - type: field_group
       name: panel_1_cards
       label: Panel 1 Cards
+      description: 'Slider with Board of Advisors'
       fields:
       - type: field_group
         name: left
@@ -191,6 +196,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'CSS Grid Classes. DO NOT EDIT'
       - name: left
         type: field_group
         config: {}
@@ -210,6 +216,7 @@ fields:
           config: {}
           template: comp-slider-block
           label: Template → [Block] Slider
+          description: 'Slider with ways to get involved'
         - name: customizations
           type: field_group
           config: {}

--- a/.forestry/front_matter/templates/page-ecosystem.yml
+++ b/.forestry/front_matter/templates/page-ecosystem.yml
@@ -13,6 +13,7 @@ fields:
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
@@ -21,18 +22,19 @@ fields:
   - type: field_group
     name: section_1
     label: Section 1
+    description: 'This begins at the top of the page and ends before 'Participation' section ends (at the end of solid white background) '
     fields:
     - type: field_group
       name: hero
       label: Hero
-      description: 'First section on page'
+      description: 'First content section on page with a textblock on the left and an image block on the right.'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Grid Classes
-        description: 'Changes CSS Classes. DO NOT EDIT'
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -42,7 +44,8 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'The textblock is editable within this section'
       - name: right
         type: field_group
         config: {}
@@ -52,14 +55,17 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Right Block
+        label: Right Column
+        description: 'The image block is editable within this section'
     - type: field_group
       name: intro_1
       label: Intro 1
+      description: 'Textblock within blue gradient and dark blue background'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Textblock is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -134,6 +140,7 @@ fields:
     - type: field_group
       name: cta_banner_1
       label: CTA Banner 1
+      description: 'Image block and textblock. The image block on the left and textblock is on the right.'
       fields:
       - name: left
         type: field_group
@@ -144,7 +151,8 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Left Block
+        label: Left Column
+        description: 'The immage is editable within this section.'
       - name: right
         type: field_group
         config: {}
@@ -154,10 +162,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Right Block
+        label: Right Column
+        description: 'The text block is editable within this section.'
     - type: field_group
       name: panel_1
       label: Panel 1
+      description: 'Text block that is above slider cards on light blue background.'
       fields:
       - name: left
         type: field_group
@@ -168,15 +178,17 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: panel_1_cards
       label: Panel 1 Cards
-      description: 'Slider with Board of Advisors'
+      description: 'Slider cards that are below text block.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Slider cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -186,6 +198,7 @@ fields:
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This section is the 'Participation' or 'Resources' section where there is a text block on the left on a sky blue background and clickable cards on the right with a dark blue background.'
     fields:
     - type: field_group
       name: resources
@@ -196,7 +209,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
-        description: 'CSS Grid Classes. DO NOT EDIT'
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -206,17 +219,18 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'The text block is editable within this section.'
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Clickable cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
           config: {}
           template: comp-slider-block
           label: Template → [Block] Slider
-          description: 'Slider with ways to get involved'
         - name: customizations
           type: field_group
           config: {}
@@ -274,11 +288,13 @@ fields:
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section begins after 'Participation' section, ends at the footer, and has a solid white background.'
     fields:
     - name: diver_deeper
       type: include
       config: {}
       template: comp-divedeeper
       label: Template → [Comp] DiveDeeper
+      description: 'Video testimonials and accompanying text'
 pages:
 - content/pages/ecosystem.json

--- a/.forestry/front_matter/templates/page-events.yml
+++ b/.forestry/front_matter/templates/page-events.yml
@@ -7,6 +7,7 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
@@ -15,6 +16,7 @@ fields:
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: navigation

--- a/.forestry/front_matter/templates/page-events.yml
+++ b/.forestry/front_matter/templates/page-events.yml
@@ -15,12 +15,13 @@ fields:
   label: Template → [Data] Open Graph & Social
 - type: field_group
   name: page_content
-  label: Page Content
+  label:  Events Page Navigation 
   description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: navigation
-    label: Navigation
+    label: Events Navigation
+    description: 'Text of events navigation is editable here.'
     fields:
     - type: field_group
       name: events

--- a/.forestry/front_matter/templates/page-fil-austin.yml
+++ b/.forestry/front_matter/templates/page-fil-austin.yml
@@ -7,18 +7,22 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
     label: Section 1
+    description: 'This section begins at the top of the page and ends after the block of paragraph text on dark blue background and right before the floating menu begins.'
     fields:
     - type: field_group
       name: mobile_hero_image
@@ -38,6 +42,7 @@ fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First content section on page with text block on the left and image block on the right.'
       fields:
       - name: left
         type: field_group
@@ -48,10 +53,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
       - type: field_group
         name: right
-        label: Right
+        label: Right Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -61,28 +68,32 @@ fields:
     - type: field_group
       name: hero_text
       label: Hero Text
+      description: 'Text block on top dark blue background that is positioned underneath the Hero text and image blocks.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
           config: {}
           template: block-text
           label: Template → [Block] Text
-      description: Text that appears below hero image.
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This section begins when floating menu appears on left, background color splits into royal blue on left and dark blue on right and stretches down to and including image that has rounded on its left side. Note that subheadings in textblocks in this section will become listed underneath headings on floating menu (ex. subheading 'What ix Filaustin' will become a list item on floating menu.)'
     fields:
     - type: field_group
       name: section_2-heading
       label: Section 2 Heading
+      description: 'Floating menu is editable within this section.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Left Column
+        description: 'Floating menu headings and panel 1 title heading are editable within this section.'
         fields:
         - type: text
           name: type
@@ -99,9 +110,11 @@ fields:
           config: {}
           template: layout-columns
           label: Columns
+          description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
         - type: field_group
           name: customizations
           label: Customizations
+          description: 'Floating menu headings are editable within this section.'
           fields:
           - type: field_group
             name: floating_menu
@@ -134,6 +147,7 @@ fields:
               - type: field_group_list
                 name: entries
                 label: Entries
+                description: 'Click 'Add Entry' to add a new heading on floating menu'
                 fields:
                 - type: text
                   name: heading
@@ -146,7 +160,8 @@ fields:
                     of the section to scroll to
       - type: field_group
         name: right
-        label: Right
+        label: Right Column
+        description: 'Hero heading to the right of start of floating menu is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -156,10 +171,12 @@ fields:
     - type: field_group
       name: section_2-info
       label: Section 2 Info
+      description: 'Image block and text block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background. Reminder that the subheading established here will appear on floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Left Column
+        description: 'The image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -168,7 +185,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right
+        label: Right Column
+        description: 'The text block is editable within this section. Reminder that the subheading established here will appear on floating menu.'
         fields:
         - type: text
           name: type
@@ -199,10 +217,12 @@ fields:
     - type: field_group
       name: section_2-banner-image
       label: Section 2 Banner Image
+      description: 'Image block at the bottom of section with left side of image rounded at corners.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
+        description: 'The image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -212,14 +232,17 @@ fields:
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section begins right after (not including) the image with rounded corners its left side and ends at subscribe form.'
     fields:
     - type: field_group
       name: section_3-panel-1
       label: Section 3 Panel 1
+      description: 'Text block to the right of floating nemu. This subheading established here will appear as item in floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
+        description: 'Text block is editable within this section.'
         fields:
         - type: text
           name: type
@@ -250,10 +273,12 @@ fields:
     - type: field_group
       name: section_3-panel-2
       label: Section 3 Panel 2
+      description: 'Image block and text block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Left Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -262,7 +287,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right
+        label: Right Column
+        description: 'Text block is editable within this section. The subheading established here will appear on floating menu.'
         fields:
         - name: text_block
           type: include
@@ -272,10 +298,12 @@ fields:
     - type: field_group
       name: section_3-banner-image
       label: Section 3 Banner Image
+      description: 'Image block with left side of image rounded at corners.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
+        description: 'The image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -285,10 +313,12 @@ fields:
     - type: field_group
       name: section_3-panel-3
       label: Section 3 Panel 3
+      description: 'Image block and text block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Left Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -297,7 +327,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right
+        label: Right Column
+        description: 'Text block is editable within this section. The subheading established here will appear on floating menu.'
         fields:
         - name: text_block
           type: include
@@ -307,14 +338,16 @@ fields:
   - type: field_group
     name: section_4
     label: Section 4
+    description: 'This section contains the Subscribe form with blue gradient border'
     fields:
     - type: field_group
       name: subscribe_form
       label: Subscribe Form
+      description: 'Subscribe form is editable within this section.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
         fields:
         - name: text_block
           type: include
@@ -388,14 +421,17 @@ fields:
   - type: field_group
     name: section_5
     label: Section 5
+    description: 'This section contains the 'Get Invovled' section and ends at Events and Hackathons section.'
     fields:
     - type: field_group
       name: section_5-title-social
       label: Section 5 Title Social
+      description: 'Text block to the right of floating nemu.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -419,6 +455,7 @@ fields:
     - type: field_group
       name: section_5-info
       label: Section 5 Info
+      description: 'Image block and text block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background.'
       fields:
       - type: field_group
         name: left
@@ -428,7 +465,8 @@ fields:
           config: {}
           template: block-image
           label: Template → [Block] Image
-        label: Left Block
+        label: Left Column
+        description: 'Image block is editable within this section.'
       - name: right
         type: field_group
         config: {}
@@ -438,14 +476,17 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Right Block
+        label: Right Column
+        description: 'Text block is editable within this section.'
     - type: field_group
       name: section_5-banner-image
       label: Section 5 Banner Image
+      description: 'Image block at the bottom of section with left side of image rounded at corners.'
       fields:
       - type: field_group
         name: left
-        label: Left
+        label: Content
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -455,6 +496,7 @@ fields:
   - type: field_group
     name: section_6
     label: Section 6
+    description: 'This section contains the Events and Hackathons section and ends at the footer.'
     fields:
     - name: events-hackathons
       type: include

--- a/.forestry/front_matter/templates/page-get-involved.yml
+++ b/.forestry/front_matter/templates/page-get-involved.yml
@@ -7,26 +7,31 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
-    label: Section 1
+    label: Content
     fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First content section on page containing text block and image' 
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'The text block is editable within this section'
         fields:
         - name: text_block
           type: include
@@ -35,7 +40,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'The image block is editable within this section'
         fields:
         - name: image_block
           type: include
@@ -45,10 +51,12 @@ fields:
     - type: field_group
       name: careers_intro
       label: Careers Intro
+      description: 'Careers section header.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'The text block is editable within this section'
         fields:
         - name: text_block
           type: include
@@ -58,15 +66,17 @@ fields:
     - type: field_group
       name: careers_list
       label: Careers List
+      description: 'Blue career cards'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - type: field_group
         name: left
-        label: Left Block
+        label: Content 
         fields:
         - type: text
           name: type
@@ -78,6 +88,7 @@ fields:
           config: {}
           template: layout-columns
           label: Columns
+          description: 'DO NOT EDIT'
         - type: field_group
           name: load_more_button
           label: Load More Button
@@ -128,15 +139,18 @@ fields:
             max: 
             labelField: 
           label: Cards
+          description: 'Click 'Add Card to add a new card to the list.' 
     - type: field_group
       name: get_involved
       label: Get Involved
+      description: 'This is the 'Participation' section with clickable square cards on right side.'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - name: left
         type: field_group
         config: {}
@@ -146,10 +160,12 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Left Block
+        label: Left Column
+        description: 'The text block is editable within this section.'
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Clickable cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -198,5 +214,6 @@ fields:
       config: {}
       template: comp-divedeeper
       label: Template → [Comp] DiveDeeper
+      description: 'Video testimonials and accompanying text'
 pages:
 - content/pages/get-involved.json

--- a/.forestry/front_matter/templates/page-governance.yml
+++ b/.forestry/front_matter/templates/page-governance.yml
@@ -7,14 +7,17 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
@@ -62,6 +65,7 @@ fields:
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This section begins at the top of the page and ends after the block of paragraph text on dark blue background and right before the floating menu begins.'
     fields:
     - type: field_group
       name: mobile_image_banner
@@ -69,7 +73,8 @@ fields:
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: ''
         fields:
         - name: image_block
           type: include
@@ -79,10 +84,12 @@ fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First content section on page with text block on the left and image block on the right.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -91,7 +98,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -101,10 +109,12 @@ fields:
     - type: field_group
       name: hero_text
       label: Hero Text
+      description: 'Text block on top dark blue background that is positioned underneath the Hero text and image blocks.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -114,14 +124,17 @@ fields:
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section begins when floating menu appears on left, background color splits into royal blue on left and dark blue on right and stretches down to and including image that has rounded on its left side. Note that subheadings in textblocks in this section will become listed underneath headings on floating menu (ex. subheading 'What exactly is an FIP' will become a list item on floating menu.)'
     fields:
     - type: field_group
       name: panel-1-title
       label: Panel 1 Title
+      description: 'Floating menu is editable within this section.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Floating menu headings and panel 1 title heading are editable within this section.'
         fields:
         - type: text
           name: type
@@ -138,9 +151,11 @@ fields:
           config: {}
           template: layout-columns
           label: Columns
+          description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
         - type: field_group
           name: customizations
           label: Customizations
+          description: 'Floating menu headings are editable within this section.'
           fields:
           - type: field_group
             name: floating_menu
@@ -153,7 +168,7 @@ fields:
               default: FloatingMenu
             - type: field_group
               name: props
-              label: Props
+              label: Content
               fields:
               - type: text
                 name: id
@@ -173,6 +188,7 @@ fields:
               - type: field_group_list
                 name: entries
                 label: Entries
+                description: 'Click 'Add Entry' to add a new heading on floating menu'
                 fields:
                 - type: text
                   name: heading
@@ -198,7 +214,8 @@ fields:
                   max: 4
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Hero heading to the right of start of floating menu is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -208,10 +225,12 @@ fields:
     - type: field_group
       name: panel-1-info-top
       label: Panel 1 Info Top
+      description: 'Image block and text block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background. Reminder that the subheading established here will appear on floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'The image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -220,7 +239,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'The text block is editable within this section. Reminder that the subheading established here will appear on floating menu.'
         fields:
         - type: text
           name: data_id
@@ -235,10 +255,12 @@ fields:
     - type: field_group
       name: panel-1-info-middle
       label: Panel 1 Info Middle
+      description: 'The second text block within this section. Reminder that the subheading established here will appear on floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'The textblock is editable within this section. Reminder that the subheading established here will appear on floating menu.'
         fields:
         - type: text
           name: data_id
@@ -253,10 +275,12 @@ fields:
     - type: field_group
       name: panel-1-info-bottom
       label: Panel 1 Info Bottom
+      description: 'The third text block within this section. Reminder that the subheading established here will appear on floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'The textblock is editable within this section. Reminder that the subheading established here will appear on floating menu.'
         fields:
         - type: text
           name: data_id
@@ -271,10 +295,12 @@ fields:
     - type: field_group
       name: panel-1-banner-image
       label: Panel 1 Banner Image
+      description: 'Image block at the bottom of section with left side of image rounded at corners.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'The image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -284,14 +310,17 @@ fields:
   - type: field_group
     name: section_4
     label: Section 4
+    description: 'This section begins right after (not including) the image with rounded corners its left side and stops after the final text block within the three blue gradient lines.'
     fields:
     - type: field_group
       name: panel-2-title
       label: Panel 2 Title
+      description: 'Text block to the right of floating nemu. This heading established here will appear as next heading in floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Text block with floating menu heading is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -301,10 +330,12 @@ fields:
     - type: field_group
       name: panel-2-info-top
       label: Panel 2 Info Top
+      description: 'Text block and image that appear underneath Panel 2 Title. Image block is on the right and text block is on the left.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -313,7 +344,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -323,10 +355,12 @@ fields:
     - type: field_group
       name: panel-2-main
       label: Panel 2 Main
+      description: 'Text block wrapped inside 3 layer gradient on dark blue background.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section. Reminder that the subheading established here will appear on floating menu.'
         fields:
         - name: text_block
           type: include
@@ -378,14 +412,17 @@ fields:
   - type: field_group
     name: section_5
     label: Section 5
+    description: 'This section begins after the final text blocks that are wrapped in 3-colored blue gradient container and extends to the 'Participation' or 'Get Involved' section.'
     fields:
     - type: field_group
       name: panel-3-title
       label: Panel 3 Title
+      description: 'Heading of section. This heading established here will appear as next heading in floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Text block with floating menu heading is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -395,10 +432,12 @@ fields:
     - type: field_group
       name: panel-3-info-top
       label: Panel 3 Info Top
+      description: 'Text block and image that appear underneath Panel 3 Title. Image block is on the right and text block is on the left.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -407,7 +446,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -417,10 +457,12 @@ fields:
     - type: field_group
       name: panel-3-info-middle
       label: Panel 3 Info Middle
+      description: 'Text block on dark blue background. Reminder that the subheading established here will appear on floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -435,10 +477,12 @@ fields:
     - type: field_group
       name: panel-3-info-bottom
       label: Panel 3 Info Bottom
+      description: 'Clickable cards to the right of the floating menu. Cards positioned on dark blue background and have an image, title and description stacked atop eachother.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Clickable cards are edited here. Note that the Title of each card will appear on the list of the floating menu.'
         fields:
         - name: slider_block
           type: include
@@ -448,14 +492,17 @@ fields:
   - type: field_group
     name: section_6
     label: Section 6
+    description: 'This section contains the 'Participation' or 'Get Involved' section.'
     fields:
     - type: field_group
       name: panel-4-title
       label: Panel 4 Title
+      description: 'Text block to the right of floating nemu. This heading established here will appear as next heading in floating menu.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Text block with floating menu heading is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -480,10 +527,12 @@ fields:
     - type: field_group
       name: panel-4-info
       label: Panel 4 Info
+      description: 'Image block and video block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -492,7 +541,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -502,10 +552,12 @@ fields:
     - type: field_group
       name: panel-4-banner-image
       label: Panel 4 Banner Image
+      description: 'Image block at the bottom of section with left side of image rounded at corners.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Image block is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -515,6 +567,7 @@ fields:
   - type: field_group
     name: section_7
     label: Section 7
+    description: 'This section contains the Events and Hackathons section and ends at the footer.'
     fields:
     - name: events-hackathons
       type: include

--- a/.forestry/front_matter/templates/page-governance.yml
+++ b/.forestry/front_matter/templates/page-governance.yml
@@ -295,7 +295,7 @@ fields:
     - type: field_group
       name: panel-1-banner-image
       label: Panel 1 Banner Image
-      description: 'Image block at the bottom of section with left side of image rounded at corners.'
+      description: 'Image block with left side of image rounded at corners.'
       fields:
       - type: field_group
         name: left
@@ -527,7 +527,7 @@ fields:
     - type: field_group
       name: panel-4-info
       label: Panel 4 Info
-      description: 'Image block and video block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background.'
+      description: 'Image block and text block. The image block is on the left and touches both the royal blue and dark blue background. The text block is on the right and has dark blue background.'
       fields:
       - type: field_group
         name: left

--- a/.forestry/front_matter/templates/page-grants.yml
+++ b/.forestry/front_matter/templates/page-grants.yml
@@ -13,6 +13,7 @@ fields:
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
@@ -21,15 +22,17 @@ fields:
   - type: field_group
     name: section_1
     label: Section 1
+    description: 'This is the first section on page, with text block on left and image within blue gradient on right.'
     fields:
     - type: field_group
       name: hero
-      label: Hero
-      description: 'First section on page'
+      label: Content
+      description: 'Text block and image are editable within this section'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -38,7 +41,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'The image is editable within this section'
         fields:
         - name: image_block
           type: include
@@ -83,14 +87,17 @@ fields:
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This begins at the point where textblock titled Developer Grants is positioned to the left of five thick vertical blue lines and cards with image and text appear to the right of five thick vertical blue lines and ends at a centered textblock with dark blue background.'
     fields:
     - type: field_group
       name: gallery-1-header
       label: Gallery 1 Header
+      description: 'Textblock and cards. Textblock is position to the left of five thick vertical blue lines and cards with image and text are to the right of five thick vertical blue lines.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Textblock is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -100,10 +107,12 @@ fields:
     - type: field_group
       name: gallery-1-cards
       label: Gallery 1 Cards
+      description: 'Cards with image and text are editable within this section.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'NEEDS TO BE EDITED ONCE VISIBLE ON FORESTRY'
         fields:
         - type: text
           name: type
@@ -178,7 +187,8 @@ fields:
         hidden: true
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'NEEDS TO BE EDITED ONCE VISIBLE ON FORESTRY'
         fields:
         - name: slider_block
           type: include
@@ -188,14 +198,16 @@ fields:
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section is the textblock that is centered within royal blue border on dark blue background.'
     fields:
     - type: field_group
       name: banner-1
       label: Banner 1
+      description: 'Textblock is editable within this section'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
         fields:
         - type: field_group
           name: customizations
@@ -245,14 +257,17 @@ fields:
   - type: field_group
     name: section_4
     label: Section 4
+    description: 'This begins at the point where textblock titled Community Grants is positioned to the left of five thick vertical blue lines and cards with image and text appear to the right of five thick vertical blue lines and ends at a centered textblock wiith tabs and dark blue background.'
     fields:
     - type: field_group
       name: gallery-2
       label: Gallery 2
+      description: 'Textblock and cards. Textblock is position to the left of five thick vertical blue lines and cards with image and text are to the right of five thick vertical blue lines.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Textblock is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -261,7 +276,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Cards with image and text are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -271,10 +287,12 @@ fields:
   - type: field_group
     name: section_5
     label: Section 5
+    description: 'This section contains an interactive slider with multiple clickable options on the left side of a centerd textblock.'
     fields:
     - type: field_group
       name: tabbed-slider
       label: Tabbed Slider
+      description: 'Slider is editable within this section.'
       fields:
       - type: text
         name: type
@@ -288,8 +306,8 @@ fields:
         default: TabbedSlider
       - type: field_group
         name: props
-        label: Props
-        description: 'Content on slides'
+        label: Content
+        description: 'Click 'Add Slide' to add another clickable option to slider.'
         fields:
         - type: field_group
           name: tabs
@@ -346,14 +364,16 @@ fields:
   - type: field_group
     name: section_6
     label: Section 6
+    description: 'This section contains a centered video and textblock with the video on the left and a textblock on the right.'
     fields:
     - type: field_group
       name: info-1
-      label: Info 1
+      label: Content
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Video block is editable within this section.'
         fields:
         - name: video_block
           type: include
@@ -369,14 +389,17 @@ fields:
           config: {}
           template: block-text
           label: Template → [Block] Text
-        label: Right Block
+        label: Right Column
+        description: 'Text block is editable within this section.'
   - type: field_group
     name: section_7
     label: Section 7
+    description: 'This section contains the 'Participation' section with clickable square cards on the right side.'
     fields:
     - type: field_group
       name: explore-panel
       label: Explore Panel
+      description: 'Text block on left and clickable cards on right.'
       fields:
       - name: grid
         type: include
@@ -386,7 +409,8 @@ fields:
         description: 'CSS Grid Classes. DO NOT EDIT'
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -395,7 +419,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Clickable cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -448,11 +473,13 @@ fields:
   - type: field_group
     name: section_8
     label: Section 8
+    description: 'This section contains the Events and Hackathons section and ends at the footer.'
     fields:
     - name: events-hackathons
       type: include
       config: {}
       template: events-hackathons
       label: Template → [Comp] Events & Hackathons
+      description: ''
 pages:
 - content/pages/grants.json

--- a/.forestry/front_matter/templates/page-grants.yml
+++ b/.forestry/front_matter/templates/page-grants.yml
@@ -7,6 +7,7 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
@@ -15,6 +16,7 @@ fields:
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
@@ -23,6 +25,7 @@ fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First section on page'
       fields:
       - type: field_group
         name: left
@@ -286,6 +289,7 @@ fields:
       - type: field_group
         name: props
         label: Props
+        description: 'Content on slides'
         fields:
         - type: field_group
           name: tabs
@@ -379,6 +383,7 @@ fields:
         config: {}
         template: grid-classes
         label: Grid Classes
+        description: 'CSS Grid Classes. DO NOT EDIT'
       - type: field_group
         name: left
         label: Left Block

--- a/.forestry/front_matter/templates/page-index.yml
+++ b/.forestry/front_matter/templates/page-index.yml
@@ -13,6 +13,7 @@ fields:
   config: {}
   template: data-open-graph-social
   label: Template → [Data] Open Graph & Social
+  description: 'Open Graph Metadata'
 - type: field_group
   name: page_content
   label: Page Content
@@ -21,15 +22,16 @@ fields:
   - type: field_group
     name: section_1
     label: Section 1
+    description: 'This begins at the top of the page and ends before 'Participation' section ends (at the end of solid white background) '
     fields:
     - type: field_group
       name: hero
       label: Hero
-      description: 'First section on page'
+      description: 'First content section on page'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
         fields:
         - name: text_block
           type: include
@@ -39,15 +41,18 @@ fields:
     - type: field_group
       name: intro_1
       label: Intro 1
+      description: 'Text block and image. The image is on the right side and contained in blue the gradient.'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Template → [Layout] Grid Alignment
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'The text is editable within this section'
         fields:
         - name: text_block
           type: include
@@ -56,7 +61,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'The image block is editable within this section'
         fields:
         - name: image_block
           type: include
@@ -108,10 +114,12 @@ fields:
     - type: field_group
       name: intro_2
       label: Intro 2
+      description: 'Video on left and text block on right.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Video block is editable within this section.'
         fields:
         - name: video_block
           type: include
@@ -120,7 +128,8 @@ fields:
           label: Template → [Block] Video
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -129,11 +138,13 @@ fields:
           label: Template → [Block] Text
     - type: field_group
       name: banner_1
-      label: Banner 1
+      label: Banner
+      description: 'Text within large blue gradient'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Banner content is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -184,16 +195,19 @@ fields:
           hidden: true
     - type: field_group
       name: explore_1
-      label: Explore 1
+      label: Explore
+      description: 'Text block on left and clickable cards on right.'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Template → [Layout] Grid Alignment
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'Text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -202,7 +216,8 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Clickable cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
@@ -212,10 +227,12 @@ fields:
     - type: field_group
       name: team_video
       label: Team Video
+      description: 'Centered video block.'
       fields:
       - type: field_group
         name: left
-        label: Left Block
+        label: Content
+        description: 'Video is editable within this section.'
         fields:
         - name: video_block
           type: include
@@ -225,6 +242,7 @@ fields:
         - type: field_group
           name: subtext
           label: Subtext
+          description: 'This text appears below video and can be linked to a URL.'
           fields:
           - type: text
             name: type
@@ -250,15 +268,18 @@ fields:
     - type: field_group
       name: grants
       label: Grants
+      description: 'Text block and image. The image is on the left side.'
       fields:
       - name: grid
         type: include
         config: {}
         template: grid-classes
         label: Template → [Layout] Grid Alignment
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'The image is editable within this section.'
         fields:
         - name: image_block
           type: include
@@ -267,7 +288,8 @@ fields:
           label: Template → [Block] Image
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'The text is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -277,6 +299,7 @@ fields:
   - type: field_group
     name: section_2
     label: Section 2
+    description: 'This is the 'Participation' section with clickable square cards on right side.'
     fields:
     - type: field_group
       name: get_involved
@@ -287,9 +310,11 @@ fields:
         config: {}
         template: grid-classes
         label: Template → [Layout] Grid Alignment
+        description: 'Selections from this dropdown will affect the section layout. DO NOT EDIT.'
       - type: field_group
         name: left
-        label: Left Block
+        label: Left Column
+        description: 'The text block is editable within this section.'
         fields:
         - name: text_block
           type: include
@@ -298,14 +323,14 @@ fields:
           label: Template → [Block] Text
       - type: field_group
         name: right
-        label: Right Block
+        label: Right Column
+        description: 'Clickable cards are editable within this section.'
         fields:
         - name: slider_block
           type: include
           config: {}
           template: comp-slider-block
           label: Template → [Block] Slider
-          description: 'Slider with ways to get involved'
         - type: field_group
           name: customizations
           label: Customizations
@@ -351,11 +376,13 @@ fields:
   - type: field_group
     name: section_3
     label: Section 3
+    description: 'This section begins after 'Participation' section, ends at the footer, and has a solid white background.'
     fields:
     - name: diver_deeper
       type: include
       config: {}
       template: comp-divedeeper
       label: Dive Deeper
+      description: 'Video testimonials and accompanying text'
 pages:
 - content/pages/index.json

--- a/.forestry/front_matter/templates/page-index.yml
+++ b/.forestry/front_matter/templates/page-index.yml
@@ -7,6 +7,7 @@ fields:
   config: {}
   template: data-seo
   label: Template → [Data] SEO
+  description: 'SEO and metadata'
 - name: og
   type: include
   config: {}
@@ -15,6 +16,7 @@ fields:
 - type: field_group
   name: page_content
   label: Page Content
+  description: The visible content on the page is editable within this section.
   fields:
   - type: field_group
     name: section_1
@@ -23,6 +25,7 @@ fields:
     - type: field_group
       name: hero
       label: Hero
+      description: 'First section on page'
       fields:
       - type: field_group
         name: left
@@ -302,6 +305,7 @@ fields:
           config: {}
           template: comp-slider-block
           label: Template → [Block] Slider
+          description: 'Slider with ways to get involved'
         - type: field_group
           name: customizations
           label: Customizations
@@ -352,6 +356,6 @@ fields:
       type: include
       config: {}
       template: comp-divedeeper
-      label: Diver Deeper
+      label: Dive Deeper
 pages:
 - content/pages/index.json

--- a/.forestry/front_matter/templates/sub-section.yml
+++ b/.forestry/front_matter/templates/sub-section.yml
@@ -7,6 +7,7 @@ fields:
   config:
     required: false
   label: Section ID
+  description: 'CSS IDs of section. DO NOT EDIT'
 - name: grid
   type: list
   config:
@@ -14,14 +15,17 @@ fields:
     min: 
     max: 
   label: Grid Classes
+  description: 'Classes of grids in subsection. DO NOT EDIT.'
 - name: classNames
   type: text
   config:
     required: false
   label: Class Names
+  description: 'Class names of subsection. DO NOT EDIT'
 - name: left
   type: blocks
   label: Left Block
+  description: 'Blocks that are positioned left. DO NOT EDIT'
   template_types:
   - text-block
   - image-block
@@ -32,6 +36,7 @@ fields:
 - name: right
   type: blocks
   label: Right Block
+  description: 'Blocks that are position right. DO NOT EDIT'
   template_types:
   - text-block
   - image-block
@@ -42,6 +47,7 @@ fields:
 - name: custom
   type: blocks
   label: Custom
+  description: 'Custom blocks. DO NOT EDIT'
   template_types:
   - events-hackathons
   config:

--- a/.forestry/front_matter/templates/text-block.yml
+++ b/.forestry/front_matter/templates/text-block.yml
@@ -8,6 +8,7 @@ fields:
     required: false
   hidden: true
   label: type
+  description: 'Do not change. This field is only visible to Forestry admins.'
   default: text_block
 - name: layout
   type: select
@@ -23,12 +24,15 @@ fields:
       section: 
       file: 
       path: 
+  hidden: true    
   label: Layout
+  description: 'Do not change. This field is only visible to Forestry admins.'
 - name: label
   type: text
   config:
     required: false
   label: Label
+  description: 'Text that will appear above heading'
 - name: heading
   type: textarea
   default: ''
@@ -38,6 +42,7 @@ fields:
     schema:
       format: markdown
   label: Heading
+  description: 'Text block heading'
 - name: subheading
   type: textarea
   default: ''
@@ -47,6 +52,7 @@ fields:
     schema:
       format: markdown
   label: Subheading
+  description: 'Text block subheading'
 - name: description
   type: textarea
   default: ''
@@ -56,3 +62,4 @@ fields:
     schema:
       format: markdown
   label: Description
+  description: 'Text block paragraph content'

--- a/content/pages/general.json
+++ b/content/pages/general.json
@@ -1,6 +1,6 @@
 {
   "seo": {
-    "title": "Filecoin Foundationsasdasdasdasdasd",
+    "title": "Filecoin Foundation",
     "description": "Filecoin Foundation - Let's build the internet of everyone"
   },
   "og": {


### PR DESCRIPTION
- Adding descriptions to field in components and pages so that users on Forestry can update content. 
- As of March 11, the following pages have been completed: Get involved, Index, Events, About, Grants. 
- Note on Forestry - grants page / section 8 / properties / events -> should have two events listed as reflected by the UI but Forestry says 'This page is empty'
- Pages that have cards, users are unable to make changes on Forestry - see screenshot for UI 
<img width="819" alt="Screen Shot 2022-03-11 at 3 36 05 PM" src="https://user-images.githubusercontent.com/67213981/157958713-38579acb-2d1d-4ab0-bc76-6f7630d253c2.png">

### General Notes
#### Governance Page: 
- Page content / section 2 / mobile banner image - we can delete this because this components uses the same image as the Hero section below it in Forestry and user can edit the image there.
- Page content / section 2 / panel 2 main - the image and heading we see on the UI is actually hard-coded into the subheading within Forestry - may need to edit this description later because it might be harder to explain since previous subheadings in the content are listed within the floating menu 
- Page content / section 5  / panel 3 info bottom - cards  ( template: comp-slider-block label: Template → [Block] Slider ) are not showing up within this section and UI says UNABLE TO SHOW "CARDS"

#### Filaustin Page:
- page content / section 1 / mobile banner image - we can delete this because this components uses the same image as the Hero section below it in Forestry and user can edit the image there.
