### PR TITLE
feat: Filter blog posts by tag

### DIFF
--- a/components/PaginatedCards.vue
+++ b/components/PaginatedCards.vue
@@ -87,7 +87,8 @@ export default {
     searchResults () {
       const query = this.searchQuery.toLowerCase()
       return this.cards.filter((post) => {
-        const matched = post.title.toLowerCase().includes(query)
+        const postTags = Array.isArray(post.tags) ? post.tags.map(item => item.toLowerCase()) : []
+        const matched = post.title.toLowerCase().includes(query) || postTags.includes(query)
         // const matched = post.title.toLowerCase().includes(query) || post.description.join('').toLowerCase().includes(query)
         if (!matched) { return false }
         return post

--- a/pages/_id.vue
+++ b/pages/_id.vue
@@ -27,7 +27,8 @@
                   <div
                     v-for="(item, index) in postTags"
                     :key="`${item}-${index}`"
-                    class="tag">
+                    class="tag"
+                    @click="setTagsQuery(item)">
                     {{ item }}
                   </div>
                 </div>
@@ -81,7 +82,7 @@
 
 <script>
 // ====================================================================== Import
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 import CloneDeep from 'lodash/cloneDeep'
 
 import BlogPageData from '@/content/pages/blog.json'
@@ -194,7 +195,7 @@ export default {
           }
         }
       }
-      return [section]
+      return { section }
     },
     postBody () {
       return this.markdown
@@ -233,6 +234,7 @@ export default {
               title: post.title,
               description: post.description,
               date: post.date || post.createdAt,
+              tags: post.tags,
               cta: {
                 type: 'H',
                 action: 'nuxt-link',
@@ -260,7 +262,20 @@ export default {
         }
       }
 
-      return [section]
+      return { section }
+    }
+  },
+
+  methods: {
+    ...mapActions({
+      clearAllTags: 'filters/clearAllTags',
+      setRouteQuery: 'filters/setRouteQuery'
+    }),
+    setTagsQuery (val) {
+      const slug = this.$Slugify(val)
+      this.clearAllTags()
+      this.setRouteQuery({ key: 'tags', data: slug })
+      this.$router.push('/blog')
     }
   }
 }
@@ -352,7 +367,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
 }
 
 // ////////////////////////////////////////////////////// Section Customizations
-::v-deep #post-heading {
+::v-deep #post-heading-section {
   padding: 0;
   margin-bottom: 3.5rem;
   .heading {
@@ -574,7 +589,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   justify-content: space-between;
 }
 
-::v-deep #blogposts-list {
+::v-deep #blogposts-section {
   padding-bottom: 3rem;
   .card {
     &.type__E {

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -40,7 +40,7 @@
 
 <script>
 // ====================================================================== Import
-import { mapGetters } from 'vuex'
+import { mapGetters, mapActions } from 'vuex'
 
 import BlogPageData from '@/content/pages/blog.json'
 
@@ -109,6 +109,7 @@ export default {
           title: post.title,
           description: post.description,
           date: post.date || post.createdAt,
+          tags: post.tags,
           cta: {
             type: 'H',
             action: 'nuxt-link',
@@ -156,7 +157,7 @@ export default {
             }
           }
         }
-        return [section]
+        return { section }
       }
       return false
     },
@@ -173,8 +174,31 @@ export default {
           displayControls: true
         }
       }
-      return [section]
+      return { section }
     }
+  },
+
+  watch: {
+    '$route' (route) {
+      if (route.query.hasOwnProperty('tags')) {
+        const value = this.$Unslugify(route.query.tags, 'capitalize-all')
+        this.setFilterValue(value)
+      }
+    }
+  },
+
+  mounted () {
+    if (this.$route.query.hasOwnProperty('tags')) {
+      const value = this.$Unslugify(this.$route.query.tags, 'capitalize-all')
+      this.setFilterValue(value)
+    }
+  },
+
+  methods: {
+    ...mapActions({
+      setFilterValue: 'core/setFilterValue',
+      setRouteQuery: 'filters/setRouteQuery'
+    })
   }
 }
 </script>
@@ -236,7 +260,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
 }
 
 // ////////////////////////////////////////////////////// Section Customizations
-::v-deep #featured-post {
+::v-deep #featured-section {
   padding: 0;
   margin-bottom: 5.5rem;
   .heading {

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -48,6 +48,23 @@ import Modal from '@/components/Modal'
 import PageSection from '@/components/PageSection'
 import BackgroundLayers from '@/components/BackgroundLayers'
 
+// =================================================================== Functions
+const unslugify = (slug, type = 'capitalize-first-character') => {
+  if (type === 'capitalize-first-character') {
+    const string = slug.toString().replace(/-/g, ' ')
+    return string.charAt(0).toUpperCase() + string.substring(1)
+  } else if (type === 'capitalize-all') {
+    return slug.toString()
+      .split('-')
+      .map(a => a.charAt(0).toUpperCase() + a.substring(1))
+      .join(' ')
+  } else if (type === 'no-capitals') {
+    return slug.toString().replace(/-/g, ' ')
+  } else {
+    return 'Incompatible "Type" specified. Must be type "capitalize-first-character", "capitalize-all" or "no-capitals". Default is "capitalize-first-character"'
+  }
+}
+
 // ====================================================================== Export
 export default {
   name: 'PageBlog',
@@ -181,7 +198,7 @@ export default {
   watch: {
     '$route' (route) {
       if (route.query.hasOwnProperty('tags')) {
-        const value = this.$Unslugify(route.query.tags, 'capitalize-all')
+        const value = unslugify(route.query.tags, 'capitalize-all')
         this.setFilterValue(value)
       }
     }
@@ -189,7 +206,7 @@ export default {
 
   mounted () {
     if (this.$route.query.hasOwnProperty('tags')) {
-      const value = this.$Unslugify(this.$route.query.tags, 'capitalize-all')
+      const value = unslugify(this.$route.query.tags, 'capitalize-all')
       this.setFilterValue(value)
     }
   },


### PR DESCRIPTION
Blog post tags on singular pages navigate to blog index with search bar pre-populated by tag name when clicked. Tags are added to the `routeQuery` object in the filters store and un-slugified using a function before populating the filter bar on the blog index page. This function might be pulled out later into the au-nuxt-module-zero helper functions plugin.