### PR TITLE
fix: Change blog page section types from arrays to objects

### DIFF
--- a/pages/_id.vue
+++ b/pages/_id.vue
@@ -194,7 +194,7 @@ export default {
           }
         }
       }
-      return [section]
+      return { section }
     },
     postBody () {
       return this.markdown
@@ -260,7 +260,7 @@ export default {
         }
       }
 
-      return [section]
+      return { section }
     }
   }
 }
@@ -352,7 +352,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
 }
 
 // ////////////////////////////////////////////////////// Section Customizations
-::v-deep #post-heading {
+::v-deep #post-heading-section {
   padding: 0;
   margin-bottom: 3.5rem;
   .heading {
@@ -574,7 +574,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   justify-content: space-between;
 }
 
-::v-deep #blogposts-list {
+::v-deep #blogposts-section {
   padding-bottom: 3rem;
   .card {
     &.type__E {

--- a/pages/blog.vue
+++ b/pages/blog.vue
@@ -156,7 +156,7 @@ export default {
             }
           }
         }
-        return [section]
+        return { section }
       }
       return false
     },
@@ -173,7 +173,7 @@ export default {
           displayControls: true
         }
       }
-      return [section]
+      return { section }
     }
   }
 }
@@ -236,7 +236,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
 }
 
 // ////////////////////////////////////////////////////// Section Customizations
-::v-deep #featured-post {
+::v-deep #featured-section {
   padding: 0;
   margin-bottom: 5.5rem;
   .heading {
@@ -315,7 +315,7 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   }
 }
 
-::v-deep #blogposts-list {
+::v-deep #blogposts-section {
   padding-top: 1.75rem;
 }
 


### PR DESCRIPTION
Fix for the updated page building structure found in the PageSection component. Page sections are generated from objects where each section corresponds to a key rather than an array of objects representing each section. The blog index and singular pages had yet to be migrated to the new structure which is what this PR addresses.