### PR TITLE
style: added hover effects to social icons in nav and footer

### DIFF
--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -215,6 +215,9 @@ export default {
       .social-icon {
         align-items: center;
         width: auto;
+        &:hover {
+          transform: scale(1.1);
+        }
         &:not(:last-child) {
           margin-right: 0;
           margin-bottom: 1rem;

--- a/components/SocialIcons.vue
+++ b/components/SocialIcons.vue
@@ -73,6 +73,11 @@ export default {
 
 .social-icon {
   width: 2rem;
+  transition: 250ms ease-out;
+  &:hover {
+    transition: 250ms ease-in;
+    transform: scale(1.2);
+  }
   &:not(:last-child) {
     margin-right: 1rem;
   }


### PR DESCRIPTION
This PR adds hover effects to social icons in navigation `scale(1.1)` and footer `scale(1.2)`