### PR TITLE
Add `.well-known/` EMS matrix delegation documents.

### DIFF
--- a/static/.well-known/matrix/client
+++ b/static/.well-known/matrix/client
@@ -1,0 +1,8 @@
+{
+    "m.homeserver": {
+        "base_url": "https://fil.ems.host"
+    },
+    "m.identity_server": {
+        "base_url": "https://vector.im"
+    }
+}

--- a/static/.well-known/matrix/server
+++ b/static/.well-known/matrix/server
@@ -1,0 +1,3 @@
+{
+    "m.server": "fil.ems.host:443"
+}


### PR DESCRIPTION
This PR adds two documents that are required for domain verification and Matrix federation/client server discovery to work properly for our EMS (Element Matrix Services) instance with a friendly server name of `fil.org`.