### PR TITLE
fix: added case to button actions for external links

### DIFF
--- a/components/Button.vue
+++ b/components/Button.vue
@@ -83,6 +83,7 @@ export default {
       let tag
       switch (action) {
         case 'a' : tag = 'a'; break
+        case 'link': tag = 'a'; break
         case 'nuxt-link' : tag = 'nuxt-link'; break
         default : tag = 'button'; break
       }


### PR DESCRIPTION
At some point the forestry option for CTA external links was changed from `a` to `link`. There was no case for `link` in the button component so this PR adds it to enable the use of both `a` and `link` to specify a button should externally link to the provided url.