### PR TITLE
feat: tab accessibility on nav dropdown menus

### DIFF
--- a/components/Navigation/NavDesktop.vue
+++ b/components/Navigation/NavDesktop.vue
@@ -20,7 +20,9 @@
           class="nav-link top-level">
           <nuxt-link
             :to="link.url"
-            class="text">
+            class="text"
+            :tabindex="(index + 1)"
+            @focus.native="setActiveItem(index)">
             {{ link.text }}
           </nuxt-link>
         </div>
@@ -28,16 +30,16 @@
 
       <NavMegaMenu
         :panel="true"
+        :active="activeItem >= 0"
         :active-index="activeItem"
         :nested-display="true">
         <NavDropdown
           v-for="(link, index) in links"
           :key="`$dropdown-${index}-${componentKey}`"
+          ref="dropdowns"
           :link="link"
-          :scroll="false"
-          :nested-display="true"
-          :class="[{ active: index === activeItem }, { last: index === lastItem && activeItem >= 0 }, index === lastItem || index === activeItem ? direction : '']"
-          behavior="hover">
+          :tab-order="index === activeItem ? (index + 1) : -1"
+          :class="[{ active: index === activeItem }, { last: index === lastItem && activeItem >= 0 }, index === lastItem || index === activeItem ? direction : '']">
         </NavDropdown>
       </NavMegaMenu>
 
@@ -139,21 +141,9 @@ export default {
   z-index: 10;
 }
 
-::v-deep .navigation {
-  &:hover {
-    .nav-dropdown-container {
-      opacity: 1;
-      transition: opacity 250ms cubic-bezier(.33, 0, .66, .33),
-        visibility 250ms linear, left 250ms ease-out, width 250ms, height 250ms, transform 250ms;
-      visibility: visible;
-      z-index: 5;
-    }
-  }
-}
-
 .nav-item-wrapper {
   position: relative;
-  padding: 1rem 0;
+  padding: 0.5rem 0;
   flex-grow: 1;
   // height: calc(100% + 2rem);
   @include small {
@@ -197,11 +187,14 @@ export default {
 .nav-link {
   color: $white;
   text-align: center;
-
   &.top-level {
     width: fit-content;
     margin-left: auto;
     margin-right: auto;
+    .text {
+      display: block;
+      padding: 0.5rem 0.75rem;
+    }
   }
 }
 

--- a/components/Navigation/NavDesktop.vue
+++ b/components/Navigation/NavDesktop.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="site-nav">
 
-    <nuxt-link to="/">
+    <nuxt-link
+      to="/"
+      tabindex="1">
       <LogoHorizontal id="logo-horizontal" />
     </nuxt-link>
 
@@ -71,7 +73,8 @@ export default {
       activeItem: -1,
       lastItem: -1,
       componentKey: 0,
-      entryAnimation: true
+      entryAnimation: true,
+      keyup: false
     }
   },
 
@@ -90,6 +93,15 @@ export default {
     }
   },
 
+  mounted () {
+    this.keyup = (e) => { this.checkForActiveElement(e) }
+    window.addEventListener('keyup', this.keyup)
+  },
+
+  beforeDestroy () {
+    if (this.keyup) { window.removeEventListener('keyup', this.keyup) }
+  },
+
   methods: {
     setActiveItem (newIndex) {
       if (newIndex >= 0) {
@@ -101,6 +113,14 @@ export default {
         }
       } else {
         this.activeItem = -1
+      }
+    },
+    checkForActiveElement (e) {
+      if (e.keyCode === 9 || e.key === 'Tab') {
+        const navActive = this.$refs.navigation.contains(document.activeElement)
+        if (!navActive) {
+          this.activeItem = -1
+        }
       }
     }
   }

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -21,7 +21,7 @@
           <div class="first-level-wrapper" @click="sublinkClicked(sublink)">
 
             <Button
-              :button="sublink"
+              :button="getButtonData(sublink)"
               :tabindex="tabOrder"
               class="nav-link first-level"
               @keyup.native.enter="sublinkClicked(sublink)">
@@ -51,6 +51,8 @@
 
 <script>
 // ===================================================================== Imports
+import CloneDeep from 'lodash/cloneDeep'
+
 import SocialIcons from '@/components/SocialIcons'
 import Button from '@/components/Button'
 
@@ -76,14 +78,25 @@ export default {
     }
   },
 
+  computed: {
+    currentPath () {
+      return this.$route.fullPath.includes(this.link.url)
+    }
+  },
+
   methods: {
+    getButtonData (sublink) {
+      const obj = CloneDeep(sublink)
+      if (this.currentPath) {
+        obj.action = 'button'
+      }
+      return obj
+    },
     sublinkClicked (sublink) {
-      const currentRoute = this.$route.fullPath
-      const hash = sublink.url.substring(sublink.url.indexOf('#') + 1)
-      const sublinkOnCurrentPage = sublink.url === currentRoute || sublink.url.startsWith(currentRoute)
-      if (!sublink.hasOwnProperty('links') && sublinkOnCurrentPage) {
+      if (this.currentPath) {
         this.$nextTick(() => {
-          const element = document.getElementById(hash) || document.querySelector(`[data-id='${hash}']`)
+          const id = sublink.url.substring(sublink.url.indexOf('#') + 1)
+          const element = document.getElementById(id) || document.querySelector(`[data-id='${id}']`)
           if (element) {
             this.$scrollToElement(element, 0, -50)
           }

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -79,8 +79,9 @@ export default {
   methods: {
     sublinkClicked (sublink) {
       const currentRoute = this.$route.fullPath
-      const hash = this.$route.hash.replace('#', '')
-      if (!sublink.hasOwnProperty('links') && sublink.url === currentRoute) {
+      const hash = sublink.url.substring(sublink.url.indexOf('#') + 1)
+      const sublinkOnCurrentPage = sublink.url === currentRoute || sublink.url.startsWith(currentRoute)
+      if (!sublink.hasOwnProperty('links') && sublinkOnCurrentPage) {
         this.$nextTick(() => {
           const element = document.getElementById(hash) || document.querySelector(`[data-id='${hash}']`)
           if (element) {

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -87,7 +87,7 @@ export default {
   methods: {
     getButtonData (sublink) {
       const obj = CloneDeep(sublink)
-      if (this.currentPath) {
+      if (this.currentPath && sublink.url.startsWith(this.link.url)) {
         obj.action = 'button'
       }
       return obj

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -78,12 +78,15 @@ export default {
 
   methods: {
     sublinkClicked (sublink) {
+      const currentRoute = this.$route.fullPath
       const hash = this.$route.hash.replace('#', '')
-      if (!sublink.hasOwnProperty('links') && sublink.url) {
-        const element = document.getElementById(hash) || document.querySelector(`[data-id='${hash}']`)
-        if (element) {
-          this.$scrollToElement(element, 0, -50)
-        }
+      if (!sublink.hasOwnProperty('links') && sublink.url === currentRoute) {
+        this.$nextTick(() => {
+          const element = document.getElementById(hash) || document.querySelector(`[data-id='${hash}']`)
+          if (element) {
+            this.$scrollToElement(element, 0, -50)
+          }
+        })
       }
     }
   }

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -9,7 +9,9 @@
 
       <nuxt-link
         v-if="link.description"
+        ref="description"
         :to="link.url"
+        :tabindex="tabOrder"
         class="extras"
         v-html="link.description">
       </nuxt-link>
@@ -20,6 +22,7 @@
 
             <Button
               :button="sublink"
+              :tabindex="tabOrder"
               class="nav-link first-level">
               {{ sublink.text }}
             </Button>
@@ -37,7 +40,7 @@
         <div class="panel-right-title">
           Community Links
         </div>
-        <SocialIcons />
+        <SocialIcons :tabindex="tabOrder" />
       </div>
     </div>
 
@@ -64,6 +67,11 @@ export default {
       type: Object,
       required: false,
       default: () => {}
+    },
+    tabOrder: {
+      type: Number,
+      required: false,
+      default: 0
     }
   },
 

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -23,7 +23,8 @@
             <Button
               :button="sublink"
               :tabindex="tabOrder"
-              class="nav-link first-level">
+              class="nav-link first-level"
+              @keyup.native.enter="sublinkClicked(sublink)">
               {{ sublink.text }}
             </Button>
 

--- a/components/Navigation/NavDropdown.vue
+++ b/components/Navigation/NavDropdown.vue
@@ -78,9 +78,8 @@ export default {
 
   methods: {
     sublinkClicked (sublink) {
-      const currentPath = this.$route.fullPath
       const hash = this.$route.hash.replace('#', '')
-      if (!sublink.hasOwnProperty('links') && sublink.url === currentPath) {
+      if (!sublink.hasOwnProperty('links') && sublink.url) {
         const element = document.getElementById(hash) || document.querySelector(`[data-id='${hash}']`)
         if (element) {
           this.$scrollToElement(element, 0, -50)

--- a/components/Navigation/NavMegaMenu.vue
+++ b/components/Navigation/NavMegaMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="container"
-    :class="['nav-dropdown-container', animationClass]"
+    :class="['nav-dropdown-container', animationClass, { active }]"
     :style="containerStyles">
 
     <div
@@ -71,6 +71,11 @@ export default {
     panel: {
       type: Boolean,
       required: false,
+      default: false
+    },
+    active: {
+      type: Boolean,
+      required: true,
       default: false
     },
     activeIndex: {
@@ -202,6 +207,13 @@ export default {
   animation-duration: 250ms;
   animation-iteration-count: 1;
   animation-fill-mode: forwards;
+  &.active {
+    opacity: 1;
+    transition: opacity 250ms cubic-bezier(.33, 0, .66, .33),
+      visibility 250ms linear, left 250ms ease-out, width 250ms, height 250ms, transform 250ms;
+    visibility: visible;
+    z-index: 5;
+  }
   &.enter {
     animation-timing-function: ease-out;
     animation-name: swingdown;

--- a/components/SocialIcons.vue
+++ b/components/SocialIcons.vue
@@ -5,6 +5,7 @@
       v-for="(icon, index) in icons"
       :key="index"
       :button="icon"
+      :tabindex="tabindex"
       class="social-icon">
 
       <component :is="icon.component" />
@@ -50,6 +51,11 @@ export default {
       type: Array,
       required: false,
       default: () => []
+    },
+    tabindex: {
+      type: Number,
+      required: false,
+      default: 0
     }
   },
 


### PR DESCRIPTION
Tab accessibility for the site nav. This solution makes use of tab indexing; because dropdown contents are not children of their respective nav headings (rather they each live in a single wrapper mega menu that is a sibling of nav headings), to ensure proper tab accessibility and flow the DOM tab order had to be overridden. The contents of each dropdown menu is given a single tab index i.e. 1, 2, 3 etc that corresponds to the tab index of the nav heading to which its menu belongs.