### PR TITLE
fix: privacy terms breadcrumbs

### DIFF
--- a/components/PageSection.vue
+++ b/components/PageSection.vue
@@ -1,57 +1,59 @@
 <template>
   <section class="page-section">
+    <template v-for="(block, key) in section">
 
-    <section
-      v-for="(block, key) in section"
-      :id="key"
-      :key="key"
-      v-if="key !== 'before'"
-      class="content-section">
+      <section
+        v-if="key !== 'before'"
+        :id="key"
+        :key="key"
+        class="content-section">
 
-      <div v-if="block.type !== 'custom'" :class="[getGridClasses(block.grid), block.classNames]">
-        <template
-          v-for="(column, columnIndex) in columns">
-          <div
-            v-if="columnExists(block, column)"
-            :key="columnIndex"
-            :class="getColumnCount(block[column])"
-            :data-push-left="getColumnPushCount(block[column], 'left')"
-            :data-push-right="getColumnPushCount(block[column], 'right')">
-            <div :class="['column-content', column]">
+        <div v-if="block.type !== 'custom'" :class="[getGridClasses(block.grid), block.classNames]">
+          <template
+            v-for="(column, columnIndex) in columns">
+            <div
+              v-if="columnExists(block, column)"
+              :key="columnIndex"
+              :class="getColumnCount(block[column])"
+              :data-push-left="getColumnPushCount(block[column], 'left')"
+              :data-push-right="getColumnPushCount(block[column], 'right')">
+              <div :class="['column-content', column]">
 
-              <!-- ================================================== Blocks -->
-              <div :class="['blocks', column]">
-                <component
-                  :is="getComponentName(block[column])"
-                  v-bind="{ block: block[column] }" />
+                <!-- ================================================== Blocks -->
+                <div :class="['blocks', column]">
+                  <component
+                    :is="getComponentName(block[column])"
+                    v-bind="{ block: block[column] }" />
+                </div>
+
+                <!-- ========================================== Customizations -->
+                <template v-if="block[column].customizations">
+                  <component
+                    :is="component.name"
+                    v-for="(component, componentKey) in block[column].customizations"
+                    :key="componentKey"
+                    v-bind="component.props" />
+                </template>
+
               </div>
-
-              <!-- ========================================== Customizations -->
-              <template v-if="block[column].customizations">
-                <component
-                  :is="component.name"
-                  v-for="(component, componentKey) in block[column].customizations"
-                  :key="componentKey"
-                  v-bind="component.props" />
-              </template>
-
             </div>
-          </div>
+          </template>
+        </div>
+
+        <template v-if="block.type === 'custom'">
+          <component
+            :is="block.component"
+            v-bind="block.props" />
         </template>
-      </div>
 
-      <template v-if="block.type === 'custom'">
-        <component
-          :is="block.component"
-          v-bind="block.props" />
-      </template>
+      </section>
 
-    </section>
+      <BackgroundLayers
+        v-else
+        :key="key"
+        v-bind="block" />
 
-    <BackgroundLayers
-      v-else
-      v-bind="block" />
-
+    </template>
   </section>
 </template>
 

--- a/content/pages/general.json
+++ b/content/pages/general.json
@@ -236,7 +236,9 @@
     "grants": "Grants",
     "get-involved": "Get Involved",
     "events": "Events",
-    "blog": "Blog"
+    "blog": "Blog",
+    "terms": "Terms of Use",
+    "policy": "Data & Privacy Policy"
   },
   "footer": {
     "text": {
@@ -267,7 +269,7 @@
         {
           "type": "F",
           "action": "nuxt-link",
-          "url": "/policy/#site-navigation",
+          "url": "/policy",
           "text": "Data & Privacy Policy"
         },
         {

--- a/modules/zero/core/components/Zero_Core__FloatingWrapper.vue
+++ b/modules/zero/core/components/Zero_Core__FloatingWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="anchor-container" ref="parent">
+  <div ref="parent" class="anchor-container">
     <div
       :class="['floating-content', { 'info-fixed': sticky }]"
       :style="{ width, transform }">
@@ -20,7 +20,6 @@ const stickyElementInViewport = (instance) => {
   const cutoffElement = document.getElementById(instance.cutoffid)
 
   if (anchorElement && cutoffElement) {
-
     const anchor = getElementDocumentCoords(anchorElement)
     const anchorWidth = `${Math.round(anchor.width)}px`
     const cutoff = getElementDocumentCoords(cutoffElement)
@@ -49,7 +48,6 @@ const stickyElementInViewport = (instance) => {
         instance.transform = 'translate(0px, 0px)'
       }
     }
-
   }
 }
 
@@ -83,7 +81,8 @@ export default {
     },
     cutoffid: {
       type: String,
-      required: false
+      required: false,
+      default: ''
     },
     bottomoffset: {
       type: Number,

--- a/modules/zero/core/components/Zero_Core__Slider.vue
+++ b/modules/zero/core/components/Zero_Core__Slider.vue
@@ -3,8 +3,8 @@
 
     <div class="slider">
       <div
-        class="slider-row-container"
-        ref="rowContainer">
+        ref="rowContainer"
+        class="slider-row-container">
         <div
           class="slider-row"
           :class="{ sliding: animate }"


### PR DESCRIPTION
Privacy and terms pages had been left out of the site breadcrumb map and were causing the page to error out/not display breadcrumbs.