### PR TITLE
feat: privacy & terms markdown

### DIFF
--- a/components/PageSection.vue
+++ b/components/PageSection.vue
@@ -1,57 +1,59 @@
 <template>
   <section class="page-section">
+    <template v-for="(block, key) in section">
 
-    <section
-      v-for="(block, key) in section"
-      :id="key"
-      :key="key"
-      v-if="key !== 'before'"
-      class="content-section">
+      <section
+        v-if="key !== 'before'"
+        :id="key"
+        :key="key"
+        class="content-section">
 
-      <div v-if="block.type !== 'custom'" :class="[getGridClasses(block.grid), block.classNames]">
-        <template
-          v-for="(column, columnIndex) in columns">
-          <div
-            v-if="columnExists(block, column)"
-            :key="columnIndex"
-            :class="getColumnCount(block[column])"
-            :data-push-left="getColumnPushCount(block[column], 'left')"
-            :data-push-right="getColumnPushCount(block[column], 'right')">
-            <div :class="['column-content', column]">
+        <div v-if="block.type !== 'custom'" :class="[getGridClasses(block.grid), block.classNames]">
+          <template
+            v-for="(column, columnIndex) in columns">
+            <div
+              v-if="columnExists(block, column)"
+              :key="columnIndex"
+              :class="getColumnCount(block[column])"
+              :data-push-left="getColumnPushCount(block[column], 'left')"
+              :data-push-right="getColumnPushCount(block[column], 'right')">
+              <div :class="['column-content', column]">
 
-              <!-- ================================================== Blocks -->
-              <div :class="['blocks', column]">
-                <component
-                  :is="getComponentName(block[column])"
-                  v-bind="{ block: block[column] }" />
+                <!-- ================================================== Blocks -->
+                <div :class="['blocks', column]">
+                  <component
+                    :is="getComponentName(block[column])"
+                    v-bind="{ block: block[column] }" />
+                </div>
+
+                <!-- ========================================== Customizations -->
+                <template v-if="block[column].customizations">
+                  <component
+                    :is="component.name"
+                    v-for="(component, componentKey) in block[column].customizations"
+                    :key="componentKey"
+                    v-bind="component.props" />
+                </template>
+
               </div>
-
-              <!-- ========================================== Customizations -->
-              <template v-if="block[column].customizations">
-                <component
-                  :is="component.name"
-                  v-for="(component, componentKey) in block[column].customizations"
-                  :key="componentKey"
-                  v-bind="component.props" />
-              </template>
-
             </div>
-          </div>
+          </template>
+        </div>
+
+        <template v-if="block.type === 'custom'">
+          <component
+            :is="block.component"
+            v-bind="block.props" />
         </template>
-      </div>
 
-      <template v-if="block.type === 'custom'">
-        <component
-          :is="block.component"
-          v-bind="block.props" />
-      </template>
+      </section>
 
-    </section>
+      <BackgroundLayers
+        v-else
+        :key="key"
+        v-bind="block" />
 
-    <BackgroundLayers
-      v-else
-      v-bind="block" />
-
+    </template>
   </section>
 </template>
 

--- a/content/pages/general.json
+++ b/content/pages/general.json
@@ -236,7 +236,9 @@
     "grants": "Grants",
     "get-involved": "Get Involved",
     "events": "Events",
-    "blog": "Blog"
+    "blog": "Blog",
+    "terms": "Terms of Use",
+    "policy": "Data & Privacy Policy"
   },
   "footer": {
     "text": {
@@ -267,7 +269,7 @@
         {
           "type": "F",
           "action": "nuxt-link",
-          "url": "/policy/#site-navigation",
+          "url": "/policy",
           "text": "Data & Privacy Policy"
         },
         {

--- a/content/privacy-policy.md
+++ b/content/privacy-policy.md
@@ -1,0 +1,102 @@
+# Privacy Policy
+_Last Updated: December 31, 2022_
+
+Filecoin Foundation and Filecoin Foundation for the Decentralized Web (collectively, "Filecoin Foundation," "we," "us") provide this Privacy Policy to explain our practices regarding the collection, use, and disclosure of your personal information both online and offline. This Privacy Policy applies to the fil.org and ffdweb.org websites ("Websites") and any websites, apps, or services that link to this Privacy Policy ("Services"), unless otherwise indicated.
+
+## I. What Personal Information is Collected
+Depending on how you interact with us, we may collect the following categories of personal information, some of which may be considered sensitive personal information under applicable laws, when you use our Services:
+
+- _Information you provide directly to us._ We may collect and store any personal information you enter on our Services or provide to us in some other manner, including personal information that may be contained in any video, comment, or other submission you upload or post to the Websites. This personal information includes:
+
+  - **Identifiers**, including your real name, postal address, e-mail address, telephone number, and other similar identifiers;
+  - **Commercial** information, including information you provide if you transact business with us or receive funding from us, such as contracted-for services, records of personal property, and financial information such as your payment method (e.g., valid credit card number, bank account information, or other financial information);
+  - **Geolocation data**, including information derived from IP address and other device information;
+  - **Demographic and profile information**, including your interests, preferences, activities, gender, age, racial or ethnic origin, and other demographic information;
+  - **Audio, electronic, or visual information**, including video, comments, or submissions uploaded to the Websites or Services; and
+  - **Inferences**, which may be drawn from any of the categories of personal information described above.
+
+- _Information we may collect automatically._ We may collect internet, electronic activity, and other information from the devices and browsers that you use, including your device type; IP address; device and advertising identifiers, probabilistic identifiers, and other unique personal or online identifiers; time zone setting and location; browser type and version; browser plug in types and versions; operating system and platform; Internet service provider; pages that you visit before and after using the Services, browsing history, and search history; the date and time of your visit; information about the links you click, pages you view, and advertising you interact with within the Services and other information about how you use the Services, and the technology on the devices you use to access these Services. If you or your device experiences an error, we collect information about the error, the time the error occurred, the feature being used, the state of the application when the error occurred, and any communications or content provided at the time the error occurred.
+
+We may aggregate or de-identify the personal information described above. Aggregated or de-identified data that we do not attempt to reidentify is not subject to this Privacy Policy.
+
+Without this personal information, we are not able to provide you with all of the requested Services.
+
+## II. Sources of Personal Information
+In addition to receiving personal information from you, we may also periodically obtain the categories of personal information described above from other sources, including from users of our Services, operating systems and platforms, social networks, government entities that make personal information publicly available, service providers, project partners and collaborators, business partners, contractors, volunteers, and other third parties.
+
+## III. How We Use Personal Information
+We may use your personal information for the following business purposes:
+
+- To provide you with access to and use of Services, including to facilitate use of our Websites, manage your account and preferences, process or fulfill orders and transactions, process payments, and provide customer service;
+- To market and advertise the Services, including emails about events and opportunities you may be interested in;
+- To evaluate and administer funding and related applications, including to review application materials and provide funding for selected proposals;
+- To help keep the Services effective and secure, including to debug to identify and repair errors that impair existing functionality;
+- To enforce our Terms of Service;
+- To identify and protect against fraudulent transactions and other misuses of our Services;
+- To analyze use of and improve our Websites and Services;
+- To contact you;
+- To comply with applicable laws and regulatory obligations; and
+- For any other purpose disclosed to you at the time we collect your personal information with your consent.
+
+We do not use or disclose sensitive personal information beyond those purposes described above.
+
+If you post personal information about yourself or others, or communicate with others using our Services, please note that we cannot control who reads your postings or what they do with the personal information you provide. We encourage you to use caution in posting personal information.
+
+## IV. Disclosure of Personal Information
+We may disclose your personal information in the following circumstances:
+
+- **Affiliates & Related Entities:** We may disclose your personal information between and among affiliates, subsidiaries, and related companies.
+- **Filecoin Foundation Working Group Participants:** We may disclose personal information, such as identifiers like real name and email, with members of working groups that Filecoin Foundation or Filecoin Foundation for the Decentralized Web participates in.
+- **Funding Programs:** We may disclose personal information, such as identifiers, financial information, and demographic information with entities with whom we co-administer grants or other funding programs, in order to evaluate funding applications and administer funding, including to review materials submitted and to provide the appropriate financing for selected proposals.
+- **Service Providers & Business Partners:** We may disclose your personal information, including identifiers, commercial information, electronic and network activity, geolocation data, demographic information, and inferences to support a variety of business purposes. These business purposes include product and service delivery, customer service, marketing, analytics services, security and performance monitoring, maintaining and servicing accounts, processing or fulfilling orders and transactions, verifying customer information, research, verifying customer information, data hosting, auditing, and data processing.
+- **Business transactions:** If we become involved with a merger, reorganization, corporate transaction, or another situation involving the transfer of some or all of our business assets, we may disclose your personal information with business entities or people involved in the negotiation or transfer.
+- **As Required by Law:** We may also collect, use, and disclose your personal information as necessary to comply with the law, respond to subpoenas, court orders, or other legal process, law enforcement requests, legal claims or government inquiries, detect fraud, and to protect and defend the rights, interests, safety and security of our Websites, Services, users, a third-party, or the public. For instance, we may disclose your personal information if we have reason to believe doing so is necessary to identify, contact or bring legal action against someone who may be causing interference with our rights or properties, or has breached an agreement, or if anyone else could be harmed by such activities or interference, if we determine an ad posted on our Services violates our terms of use or the rights of a third party, or if there is an emergency involving danger to any person.
+- **With your consent:** We may also disclose personal information about you with other entities if you give us permission.
+
+Please note that if you post any of your personal information via the Services, such personal information may be viewed, collected, and used by others over whom we have no control. We are not responsible for the use by third parties of personal information you post or otherwise make public.
+
+We do not sell personal information to third parties for monetary or other valuable consideration as defined by applicable law or share personal information for purposes of cross-contextual behavioral or targeted advertising.
+
+## V. Cookies
+"Cookies" are small text files that allow websites to store and retrieve information about you from your computer system. We may serve cookies to track individual site usage for later aggregation. If you do not want information collected through the use of cookies, there is a procedure in most browser settings that allows you to automatically decline cookies, or be given the choice of declining or accepting the transfer to your computer of a particular cookie (or cookies) from a particular site. You may wish to refer to allaboutcookies.org/manage-cookies. If you reject cookies through your browser settings, you may still use our Services, but you may experience some inconvenience.
+
+## VI. Your Rights
+Depending on where you reside, you may be entitled to request access to, portability, correction, and deletion of your personal information.
+
+- **Right to Know:** You may have the right to know what personal information we have collected about you, including the categories of personal information, the categories of sources from which it is collected, the business or commercial purposes for collecting, selling, or sharing it, and the categories of third parties to whom we disclose it.
+- **Right to Access & Data Portability:** Subject to certain exceptions, you may have the right to request a copy of the personal information we collected about you.
+- **Right to Correction and Deletion:** You may have the right to request that we correct or delete personal information that we collected from you and retain, subject to certain exceptions.
+
+To exercise your access, portability, correction, and deletion rights, you may submit a request by e-mail at privacypolicy@fil.org or by leaving a message at (302) 440-4493. Once we receive your request, we may verify it by requesting information sufficient to confirm your identity. You may also be entitled, in accordance with applicable law, to appeal a refusal to take action on your request; to do so please respond to the email denying your request.
+
+Only you, or a person authorized by you to act on your behalf, may make a verifiable consumer request related to your personal information. If you would like to use an authorized agent to exercise your rights, we may request evidence that you have provided such agent with power of attorney or that the agent otherwise has valid written authority to submit requests to exercise rights on your behalf. We reserve the right to deny requests in certain circumstances, such as where we have a reasonable belief that the request is fraudulent, where your identity cannot be confirmed, or where we must maintain your personal information consistent with applicable law.
+
+Note that while some of the personal information that we collect about you may be considered sensitive personal information, we process such information for only those purposes detailed in this Privacy Policy and as authorized by law. For example, we might process your sensitive personal information in order to provide the services you request from us.
+
+## VII. Other California Rights
+- **Do Not Track:** Our systems do not at this time have the necessary programming to honor "Do Not Track" or "DNT" browser signals. Please return to this Privacy Policy in future for further updates on this topic.
+- **Shine the Light:** California residents who provide certain personal information in connection with obtaining products or services for personal, family or household use are entitled to request and obtain from us once a calendar year information about the customer information we disclosed, if any, with other businesses for their own direct marketing uses. If applicable, this information would include the categories of customer information and the names and addresses of those businesses with which we disclosed customer information for the immediately prior calendar year.
+
+## VIII. Communication from Us
+From time to time, we may send you information with announcements and updates about the Websites and the Services. You may elect to opt-out of ongoing e-mail communication from us, such as newsletters, subscriptions, and inquiries.
+
+## IX. Children
+The Websites and Services are not intended for children under the age of 16 nor do we knowingly collect personal information from children under 16. We do not knowingly sell or share personal information of individuals under the age of 16.
+
+## X. Links to Other Sites
+The Services may provide links and pointers to websites maintained by other organizations. We provide these links as a convenience to users, but we do not operate, control, or endorse such sites. We also disclaim any responsibility for the information on those sites and any products or services offered there, and cannot vouch for the privacy policies of such sites. We do not make any warranties or representations that any linked websites will function without error or interruption, or that defects will be corrected.
+
+## XI. E-Commerce
+We may have links to outside websites where you may engage in transactions. We are not responsible for transactions conducted on those sites and cannot vouch for the security of the personal information submitted in those transactions. We have no control over the content and security practices of outside websites.
+
+## XII. Security and Retention
+Personal information will be retained only for so long as reasonably necessary and proportionate for the purposes set out above in accordance with applicable law and based on the criteria set out in this Privacy Policy. We have in place commercially reasonable technological and procedural security measures in an attempt to protect and safeguard the security of the personal information. Despite these efforts, please understand that no system is perfect or can guarantee that unauthorized access or theft of data might not occur.
+
+## XIII. Changes to this Privacy Policy
+We may amend this Privacy Policy at any time, so please review it frequently. If we make a material change to this Privacy Policy, we will update the Last Updated date on this notice.
+
+## XIV. Policy Acceptance
+By using the Services, you signify your acknowledgment of this Privacy Policy. If you do not agree or are not comfortable with any policy described in this Privacy Policy, you may discontinue use of the Services.
+
+## XV. More Questions?
+If you have any questions about this Privacy Policy, email them to privacypolicy@fil.org and be sure to indicate the specific site you're visiting and the nature of your question or concern.

--- a/content/terms-of-use.md
+++ b/content/terms-of-use.md
@@ -1,0 +1,62 @@
+# Terms of Use
+
+Effective Date:  October 20, 2021
+
+These Terms of Use (“Terms”) govern your use of the Filecoin Foundation website and any other website that the Filecoin Foundation operates and that links to these Terms (collectively, the “Website”).  
+
+Please review these Terms carefully before using the Website. We may change these Terms or modify any features of the Website at any time.  The most current version of the Terms can be viewed by clicking on the “Terms of Use” link posted through the Website.  You accept the Terms by using the Website, and you accept any changes to the Terms by continuing to use the Website after we post the changes.  
+
+
+## Privacy  
+
+By using the Website, you consent to our processing your information consistent with our [Privacy Policy](https://fil.org/policy)
+
+
+## Prohibited Conduct
+
+You may not access or use, or attempt to access or use, the Website to take any action that could harm us or any third party, interfere with the operation of the Website, or use the Website in a manner that violates any laws. For example, and without limitation, you may not:
+engage in unauthorized spidering, “scraping,” or harvesting of content or personal information, or use any other unauthorized automated means to compile information;
+take any action that imposes an unreasonable or disproportionately large load on our network or infrastructure;
+use any device, software, or routine to interfere or attempt to interfere with the proper working of the Website or any activity conducted on the Website or attempt to probe, scan, test the vulnerability of, or breach the security of any system or network;
+attempt to decipher, decompile, disassemble, or reverse-engineer any of the software comprising or in any way making up a part of the Website;
+engage in any other conduct that restricts or inhibits any person from using or enjoying the Website, or that, in our sole judgment, exposes us or any of our users, affiliates, or any other third party to any liability, damages, or detriment of any type.
+
+Violations of system or network security may result in civil or criminal liability.  We may investigate and work with law enforcement authorities to prosecute users who violate these Terms.  We may suspend or terminate your access to the Website for any or no reason at any time without notice.
+
+
+## Intellectual Property
+
+The Website is owned and operated by the Filecoin Foundation. You acknowledge and agree that, as between the parties, we own all right, title and interest in and to the Website, including: (a) all information, data, software, text, displays and visual interfaces, graphics, images, video, and audio, and all other elements of the Website, and the design, selection, and arrangement thereof; and (b) all intellectual property and other legal rights (including, but not limited to, any and all copyrights, patents, patent applications, trade secrets, trademarks and other intangible rights) therein. You may not publish, reproduce, distribute, display, perform, edit, adapt, modify, or otherwise exploit any part of the Website without our written consent. You will not earn or acquire any ownership rights in any copyrights, patents, trade secrets, trademarks or other intellectual property rights on account of these Terms or any access to or use of the Website.
+
+
+## Links to third-party content  
+
+The Website may contain links to third-party content.  We do not control, endorse, sponsor, recommend, or otherwise accept responsibility for such content.  Use of any linked third-party content is at your own risk.
+
+
+## Communications with you
+
+If you provide your email address or other contact information to us, we may communicate with you about the Website and our products and services, including through one or more third party e-mail or survey services, via the contact information you provide to us through the Website.  You consent to receive communications from us that may: (i) solicit feedback via e-mail, surveys, bug reports, or other methods we may determine; (ii) collect additional information regarding issues you report in your feedback; (iii) notify you of changes to the Website, our products or services, or these Terms; and (iv) tell you about our programs, products or services.
+
+
+*DISCLAIMER OF WARRANTIES; LIMITATION OF LIABILITY*
+
+YOUR USE OF THE WEBSITE IS AT YOUR OWN RISK. THE WEBSITE IS PROVIDED “AS IS” WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR OTHER VIOLATION OF RIGHTS. WE DO NOT WARRANT THE ADEQUACY, CURRENCY, ACCURACY, LIKELY RESULTS, OR COMPLETENESS OF THE WEBSITE OR ANY THIRD-PARTY SITES LINKED TO OR FROM THE WEBSITE, OR THAT THE FUNCTIONS PROVIDED WILL BE UNINTERRUPTED, VIRUS, OR ERROR-FREE. WE EXPRESSLY DISCLAIM ANY LIABILITY FOR ANY ERRORS OR OMISSIONS IN THE CONTENT INCLUDED IN THE WEBSITE OR ANY THIRD-PARTY SITES LINKED TO OR FROM THE WEBSITE. SOME JURISDICTIONS MAY NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SOME OF THE ABOVE EXCLUSIONS MAY NOT APPLY TO YOU.
+
+IN NO EVENT WILL WE, OR OUR AFFILIATES, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS, OR ASSIGNS BE LIABLE FOR ANY DIRECT OR INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, LOST PROFITS, OR OTHER DAMAGES WHATSOEVER ARISING IN CONNECTION WITH THE USE OF THE WEBSITE, ANY INTERRUPTION IN AVAILABILITY OF THE WEBSITE, DELAY IN OPERATION OR TRANSMISSION, COMPUTER VIRUS, LOSS OF DATA, OR USE, MISUSE, RELIANCE, REVIEW, MANIPULATION, OR OTHER UTILIZATION IN ANY MANNER WHATSOEVER OF THE WEBSITE OR THE DATA COLLECTED THROUGH THE WEBSITE, EVEN IF ONE OR MORE OF THEM HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES OR LOSS.  ANY CLAIM ARISING OUT OF OR CONNECTED WITH THE WEBSITE WILL BE LIMITED TO THE GREATER OF $100 OR THE AMOUNT THAT YOU PAID TO ACCESS THE WEBSITE.
+
+
+*INDEMNIFICATION*
+
+YOU AGREE TO INDEMNIFY, DEFEND AND HOLD US AND OUR AFFILIATES, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND ASSIGNS HARMLESS FROM AND AGAINST ANY AND ALL LOSSES, COSTS, EXPENSES (INCLUDING REASONABLE ATTORNEYS’ FEES AND EXPENSES), CLAIMS, DAMAGES AND LIABILITIES RELATED TO OR ASSOCIATED WITH YOUR USE OF THE WEBSITE AND ANY ALLEGED VIOLATION BY YOU OF THESE TERMS.  WE RESERVE THE RIGHT TO ASSUME THE EXCLUSIVE DEFENSE OF ANY CLAIM FOR WHICH WE ARE ENTITLED TO INDEMNIFICATION UNDER THIS SECTION.  IN SUCH EVENT, YOU SHALL PROVIDE US WITH SUCH COOPERATION AS WE REASONABLY REQUEST.
+
+
+*CHOICE OF LAW AND FORUM*
+
+You agree that your access to and use of the Website will be governed by and will be construed in accordance with the law of the State of California without regard to principles of conflicts of laws.  You agree that any claim or dispute against us arising out of or relating to the Website must be resolved by a federal district court located in California, unless agreed upon by all parties.
+
+
+## Miscellaneous
+
+
+These Terms constitute the entire agreement between you and us, superseding any prior or contemporaneous communications and proposals (whether oral, written or electronic) between you and us, regarding the subject matter hereof.  In the event that any provision of these Terms is held unenforceable, it will not affect the validity or enforceability of the remaining provisions and will be replaced by an enforceable provision that comes closest to the intention underlying the unenforceable provision. You agree that no joint venture, partnership, employment, or agency relationship exists between you and us as a result of these Terms or your access to and use of the Website.  Our failure to enforce any provisions of these Terms or respond to a violation by any party does not waive our right to subsequently enforce any terms or conditions of the Terms or respond to any violations.  Nothing contained in these Terms is in derogation of our right to comply with governmental, court, and law enforcement requests or requirements relating to your use of the Website or information provided to or gathered by us with respect to such use.

--- a/modules/zero/core/components/Zero_Core__FloatingWrapper.vue
+++ b/modules/zero/core/components/Zero_Core__FloatingWrapper.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="anchor-container" ref="parent">
+  <div ref="parent" class="anchor-container">
     <div
       :class="['floating-content', { 'info-fixed': sticky }]"
       :style="{ width, transform }">
@@ -20,7 +20,6 @@ const stickyElementInViewport = (instance) => {
   const cutoffElement = document.getElementById(instance.cutoffid)
 
   if (anchorElement && cutoffElement) {
-
     const anchor = getElementDocumentCoords(anchorElement)
     const anchorWidth = `${Math.round(anchor.width)}px`
     const cutoff = getElementDocumentCoords(cutoffElement)
@@ -49,7 +48,6 @@ const stickyElementInViewport = (instance) => {
         instance.transform = 'translate(0px, 0px)'
       }
     }
-
   }
 }
 
@@ -83,7 +81,8 @@ export default {
     },
     cutoffid: {
       type: String,
-      required: false
+      required: false,
+      default: ''
     },
     bottomoffset: {
       type: Number,

--- a/modules/zero/core/components/Zero_Core__Slider.vue
+++ b/modules/zero/core/components/Zero_Core__Slider.vue
@@ -3,8 +3,8 @@
 
     <div class="slider">
       <div
-        class="slider-row-container"
-        ref="rowContainer">
+        ref="rowContainer"
+        class="slider-row-container">
         <div
           class="slider-row"
           :class="{ sliding: animate }"

--- a/pages/policy.vue
+++ b/pages/policy.vue
@@ -7,81 +7,7 @@
         <div class="col-10_mi-11" data-push-left="off-2_mi-1">
           <div class="content">
 
-            <h1>Privacy policy</h1>
-
-            <h2>Filecoin Foundation respects your privacy. Here’s our privacy policy for your use of the Services (as defined in our Terms of Service) and your use of the fil.org website.</h2>
-
-            <h2>Personally Identifiable Information</h2>
-
-            <p>We will not provide anyone else outside of our company with any information specific to you collected by us unless we have your consent. Our only employees or consultants allowed access to personal information about you are those who need to have access. Any employee or consultant who violates our privacy and security policies is subject to disciplinary action, including possible termination or prosecution.</p>
-
-            <h2>What Information is Collected and Used:</h2>
-
-            <p>We may collect personal information that can identify you, such as your name and email address, and other information that does not identify you. When you provide personal information through our website, the information may be sent to servers located in other countries around the world.</p>
-
-            <p>We may collect and store any personal information you enter on our website or provide to us in some other manner, including personal information that may be contained in any video, comment or other submission you upload or post to the website. This includes identifying information, such as your name, address, e-mail address, and telephone number; your likeness; and, if you transact business with us, financial information such as your payment method (valid credit card number, type, expiration date or other financial information).</p>
-
-            <p>We also may request information about your interests and activities, your gender and age, and other demographic information.</p>
-
-            <p>We may also periodically obtain both personal and non-personal information about you from business partners, contractors and other third parties. Examples of information that we may receive include demographic information.</p>
-
-            <p><strong>We may use this information to:</strong></p>
-
-            <p>Fulfill your requests for products and services; Customize the advertising and content that you see on our website;</p>
-
-            <ul>
-              <li>Enforce our Terms of Service</li>
-              <li>Identify and protect against fraudulent transactions and other misuses of our website;</li>
-              <li>Analyze use of and improve our website, products and services;</li>
-              <li>Manage your account and your preferences;</li>
-              <li>Facilitate use of our website;</li>
-              <li>Offer products and services that may be of interest to you;</li>
-            </ul>
-
-            <p>We may share aggregated, non-personal information in any of the above situations and also with advertisers and others.</p>
-
-            <p>If you post information about yourself or others, or communicate with others using our website, please note that we cannot control who reads your postings or what they do with the information you provide. We encourage you to use caution in posting personal information.</p>
-
-            <p>We may disclose your personal information if (i) required to do so by law, court order or subpoena, or as requested by other government, law enforcement, or investigative authority, (ii) we in good faith believe that such disclosure is necessary or advisable, including without limitation to protect our rights or properties, (iii) we have reason to believe that disclosing your personal information is necessary to identify, contact or bring legal action against someone who may be causing interference with our rights or properties, or has breached an agreement, or if anyone else could be harmed by such activities or interference, (iv) if we determine an ad posted violates our terms of use or the rights of a third party, or (v) there is an emergency involving personal danger.</p>
-
-            <p>Please note that if you post any of your personal information via the Services, such information may be collected and used by others over whom we have no control. We are not responsible for the use by third parties of information you post or otherwise make public.</p>
-
-            <h2>Cookies</h2>
-
-            <p>“Cookies” are small text files that allow Websites to store and retrieve information about you from your computer system. We serve cookies to track individual site usage for later aggregation. But we do not use cookies in order to retrieve any information from your computer other than information originally sent in a Website cookie, such as a user code. We have no control over whether and how our advertisers use cookies that originate from their website.</p>
-
-            <p><strong>Communication from Us</strong></p>
-
-            <p>From time to time, we may send you information with announcements and updates about the Website, the Services, and your account. You may elect to opt-out of ongoing e-mail communication from us, such as newsletters, subscriptions, inquiries, etc. by using a simple “opt out” procedure. You need only reply to the communication with the word “unsubscribe” (without the quotation marks) in the body of your e-mail response and your name will be removed from that mailing list. However, if you opt-out of receiving our announcements and updates about your account, you may no longer have access to areas restricted to account members.</p>
-
-            <p><strong>Children</strong></p>
-
-            <p>The Website and Services is not intended for children under the age of 18 nor do we knowingly collect personal information from children under 18. Company does not orient the Website toward children or target them as an audience, nor does it screen them from using Company.</p>
-
-            <p><strong>Links to Other sites</strong></p>
-
-            <p>The Website provides links and pointers to Web sites maintained by other organizations. We provide these links as a convenience to users, but it does not operate, control or endorse such sites. We also disclaim any responsibility for the information on those sites and any products or services offered there, and cannot vouch for the privacy policies of such sites. We do not make any warranties or representations that any linked sites (or even the Website) will function without error or interruption, that defects will be corrected.</p>
-
-            <p><strong>E-Commerce</strong></p>
-
-            <p>All commerce transactions that take place on the Website are processed securely in order to make every reasonable effort to insure that your personal information is protected. Any transactions that take place on other sites that have links from the Website are not necessarily handled in this fashion. We disclaim any responsibility for transactions conducted on those sites and cannot vouch for the security of the information submitted in those transactions.</p>
-
-            <p>We have implemented processes intended to protect user information and maintain security of data. Each account holder is assigned a unique username and password, which is required to access their account. It is your responsibility to protect the security of this login information.</p>
-
-            <p>We have attempted to protect ours servers by locating them in areas with security procedures, use of firewalls and implementing other generally available security technologies. These safeguards help prevent unauthorized access, maintain data accuracy, and ensure the appropriate use of data, but no guarantee can be made that your information and data will be secure from intrusions and unauthorized release to 3rd parties.</p>
-
-            <p><strong>Policy Acceptance</strong></p>
-
-            <p>By using the Website and the Services, you signify your acceptance of this Privacy Policy. If you do not agree or are not comfortable with any policy described in this Privacy Policy, you may discontinue use of the Website or the Services.</p>
-
-            <p><strong>More Questions?</strong></p>
-
-            <p>If you have any questions about this privacy policy, email them to
-              <a href="mailto:hello@fil.org">
-                hello@fil.org
-              </a>
-              and be sure to indicate the specific site you’re visiting and the nature of your question or concern.
-            </p>
+            <nuxt-content :document="markdown" />
 
           </div>
         </div>
@@ -109,6 +35,15 @@ export default {
 
   components: {
     BackgroundLayers
+  },
+
+  async asyncData ({ $content, app, store, route, error }) {
+    try {
+      const markdown = await $content('privacy-policy').fetch()
+      return { markdown }
+    } catch (e) {
+      return error('Could not find privacy policy content')
+    }
   },
 
   data () {
@@ -167,18 +102,19 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   z-index: 10;
 }
 
-h1, p {
+::v-deep h1,
+::v-deep p {
   margin-bottom: 2rem;
 }
 
-h2 {
+::v-deep h2 {
   @include fontSize_Large;
   @include fontWeight_SemiBold;
   margin-top: 3rem;
   margin-bottom: 2rem;
 }
 
-p {
+::v-deep p {
   a {
     @include fontWeight_Bold;
     &:hover {
@@ -190,7 +126,7 @@ p {
   }
 }
 
-ul {
+::v-deep ul {
   margin-left: 1.125rem;
   margin-bottom: 2rem;
 }

--- a/pages/terms.vue
+++ b/pages/terms.vue
@@ -7,51 +7,7 @@
         <div class="col-10_mi-11" data-push-left="off-2_mi-1">
           <div class="content">
 
-            <h1>Terms of Use</h1>
-
-            <p>Effective Date:  October 20, 2021</p>
-            <p>These Terms of Use (“Terms”) govern your use of the Filecoin Foundation website and any other website that the Filecoin Foundation operates and that links to these Terms (collectively, the “Website”).</p>
-            <p>Please review these Terms carefully before using the Website. We may change these Terms or modify any features of the Website at any time.  The most current version of the Terms can be viewed by clicking on the “Terms of Use” link posted through the Website.  You accept the Terms by using the Website, and you accept any changes to the Terms by continuing to use the Website after we post the changes.</p>
-
-            <h2>Privacy</h2>
-
-            <p>
-              By using the Website, you consent to our processing your information consistent with our
-              <nuxt-link to="/policy">
-                Privacy Policy
-              </nuxt-link>
-            </p>
-
-            <h2>Prohibited Conduct</h2>
-
-            <p></p>
-
-            <p>You may not access or use, or attempt to access or use, the Website to take any action that could harm us or any third party, interfere with the operation of the Website, or use the Website in a manner that violates any laws. For example, and without limitation, you may not:<br />engage in unauthorized spidering, “scraping,” or harvesting of content or personal information, or use any other unauthorized automated means to compile information;<br />take any action that imposes an unreasonable or disproportionately large load on our network or infrastructure;<br />use any device, software, or routine to interfere or attempt to interfere with the proper working of the Website or any activity conducted on the Website or attempt to probe, scan, test the vulnerability of, or breach the security of any system or network;<br />attempt to decipher, decompile, disassemble, or reverse-engineer any of the software comprising or in any way making up a part of the Website;<br />engage in any other conduct that restricts or inhibits any person from using or enjoying the Website, or that, in our sole judgment, exposes us or any of our users, affiliates, or any other third party to any liability, damages, or detriment of any type.</p>
-
-            <p>Violations of system or network security may result in civil or criminal liability.  We may investigate and work with law enforcement authorities to prosecute users who violate these Terms.  We may suspend or terminate your access to the Website for any or no reason at any time without notice.</p>
-
-            <h2>Intellectual Property</h2>
-
-            <p>The Website is owned and operated by the Filecoin Foundation. You acknowledge and agree that, as between the parties, we own all right, title and interest in and to the Website, including: (a) all information, data, software, text, displays and visual interfaces, graphics, images, video, and audio, and all other elements of the Website, and the design, selection, and arrangement thereof; and (b) all intellectual property and other legal rights (including, but not limited to, any and all copyrights, patents, patent applications, trade secrets, trademarks and other intangible rights) therein. You may not publish, reproduce, distribute, display, perform, edit, adapt, modify, or otherwise exploit any part of the Website without our written consent. You will not earn or acquire any ownership rights in any copyrights, patents, trade secrets, trademarks or other intellectual property rights on account of these Terms or any access to or use of the Website.</p>
-
-            <h2>Links to third-party content</h2>
-
-            <p>The Website may contain links to third-party content.  We do not control, endorse, sponsor, recommend, or otherwise accept responsibility for such content.  Use of any linked third-party content is at your own risk.</p>
-
-            <h2>Communications with you</h2>
-
-            <p>If you provide your email address or other contact information to us, we may communicate with you about the Website and our products and services, including through one or more third party e-mail or survey services, via the contact information you provide to us through the Website.  You consent to receive communications from us that may: (i) solicit feedback via e-mail, surveys, bug reports, or other methods we may determine; (ii) collect additional information regarding issues you report in your feedback; (iii) notify you of changes to the Website, our products or services, or these Terms; and (iv) tell you about our programs, products or services.</p>
-            <p><em>DISCLAIMER OF WARRANTIES; LIMITATION OF LIABILITY</em></p>
-            <p>YOUR USE OF THE WEBSITE IS AT YOUR OWN RISK. THE WEBSITE IS PROVIDED “AS IS” WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, OR OTHER VIOLATION OF RIGHTS. WE DO NOT WARRANT THE ADEQUACY, CURRENCY, ACCURACY, LIKELY RESULTS, OR COMPLETENESS OF THE WEBSITE OR ANY THIRD-PARTY SITES LINKED TO OR FROM THE WEBSITE, OR THAT THE FUNCTIONS PROVIDED WILL BE UNINTERRUPTED, VIRUS, OR ERROR-FREE. WE EXPRESSLY DISCLAIM ANY LIABILITY FOR ANY ERRORS OR OMISSIONS IN THE CONTENT INCLUDED IN THE WEBSITE OR ANY THIRD-PARTY SITES LINKED TO OR FROM THE WEBSITE. SOME JURISDICTIONS MAY NOT ALLOW THE EXCLUSION OF IMPLIED WARRANTIES, SO SOME OF THE ABOVE EXCLUSIONS MAY NOT APPLY TO YOU.</p>
-            <p>IN NO EVENT WILL WE, OR OUR AFFILIATES, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS, OR ASSIGNS BE LIABLE FOR ANY DIRECT OR INDIRECT, SPECIAL, INCIDENTAL, CONSEQUENTIAL OR PUNITIVE DAMAGES, LOST PROFITS, OR OTHER DAMAGES WHATSOEVER ARISING IN CONNECTION WITH THE USE OF THE WEBSITE, ANY INTERRUPTION IN AVAILABILITY OF THE WEBSITE, DELAY IN OPERATION OR TRANSMISSION, COMPUTER VIRUS, LOSS OF DATA, OR USE, MISUSE, RELIANCE, REVIEW, MANIPULATION, OR OTHER UTILIZATION IN ANY MANNER WHATSOEVER OF THE WEBSITE OR THE DATA COLLECTED THROUGH THE WEBSITE, EVEN IF ONE OR MORE OF THEM HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES OR LOSS.  ANY CLAIM ARISING OUT OF OR CONNECTED WITH THE WEBSITE WILL BE LIMITED TO THE GREATER OF $100 OR THE AMOUNT THAT YOU PAID TO ACCESS THE WEBSITE.</p>
-            <p><em>INDEMNIFICATION</em></p>
-            <p>YOU AGREE TO INDEMNIFY, DEFEND AND HOLD US AND OUR AFFILIATES, DIRECTORS, OFFICERS, EMPLOYEES, AGENTS AND ASSIGNS HARMLESS FROM AND AGAINST ANY AND ALL LOSSES, COSTS, EXPENSES (INCLUDING REASONABLE ATTORNEYS’ FEES AND EXPENSES), CLAIMS, DAMAGES AND LIABILITIES RELATED TO OR ASSOCIATED WITH YOUR USE OF THE WEBSITE AND ANY ALLEGED VIOLATION BY YOU OF THESE TERMS.  WE RESERVE THE RIGHT TO ASSUME THE EXCLUSIVE DEFENSE OF ANY CLAIM FOR WHICH WE ARE ENTITLED TO INDEMNIFICATION UNDER THIS SECTION.  IN SUCH EVENT, YOU SHALL PROVIDE US WITH SUCH COOPERATION AS WE REASONABLY REQUEST.</p>
-            <p><em>CHOICE OF LAW AND FORUM</em></p>
-            <p>You agree that your access to and use of the Website will be governed by and will be construed in accordance with the law of the State of California without regard to principles of conflicts of laws.  You agree that any claim or dispute against us arising out of or relating to the Website must be resolved by a federal district court located in California, unless agreed upon by all parties.</p>
-
-            <h2>Miscellaneous</h2>
-
-            <p>These Terms constitute the entire agreement between you and us, superseding any prior or contemporaneous communications and proposals (whether oral, written or electronic) between you and us, regarding the subject matter hereof.  In the event that any provision of these Terms is held unenforceable, it will not affect the validity or enforceability of the remaining provisions and will be replaced by an enforceable provision that comes closest to the intention underlying the unenforceable provision. You agree that no joint venture, partnership, employment, or agency relationship exists between you and us as a result of these Terms or your access to and use of the Website.  Our failure to enforce any provisions of these Terms or respond to a violation by any party does not waive our right to subsequently enforce any terms or conditions of the Terms or respond to any violations.  Nothing contained in these Terms is in derogation of our right to comply with governmental, court, and law enforcement requests or requirements relating to your use of the Website or information provided to or gathered by us with respect to such use.</p>
+            <nuxt-content :document="markdown" />
 
           </div>
         </div>
@@ -79,6 +35,15 @@ export default {
 
   components: {
     BackgroundLayers
+  },
+
+  async asyncData ({ $content, app, store, route, error }) {
+    try {
+      const markdown = await $content('terms-of-use').fetch()
+      return { markdown }
+    } catch (e) {
+      return error('Could not find terms content')
+    }
   },
 
   data () {
@@ -137,18 +102,19 @@ $backgroundLayers__Left__Mini: 0.25rem * 6;
   z-index: 10;
 }
 
-h1, p {
+::v-deep h1,
+::v-deep p {
   margin-bottom: 2rem;
 }
 
-h2 {
+::v-deep h2 {
   @include fontSize_Large;
   @include fontWeight_SemiBold;
   margin-top: 3rem;
   margin-bottom: 2rem;
 }
 
-p a {
+::v-deep p a {
   @include fontWeight_Bold;
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
Privacy policy and terms pages previous had content directly in the html. This content has been migrated to markdown files stored in the content directory; `/content/privacy-policy.md` and `/content/terms-of-use.md`, respectively. 